### PR TITLE
Rustier boot

### DIFF
--- a/src/c/src.c
+++ b/src/c/src.c
@@ -1,54 +1,5 @@
 #include "os.h"
-#include "os_io_seproxyhal.h"
-
-
-
-
-extern void sample_main();
 
 void os_longjmp(unsigned int exception) {
   longjmp(try_context_get()->jmp_buf, exception);
-}
-
-io_seph_app_t G_io_app;
-
-int c_main(void) {
-  __asm volatile("cpsie i");
-  unsigned int r9_reg = pic_internal(0xc0d00000);
-  __asm volatile("mov r9, %0":"=r"(r9_reg)::"r9");
-
-  // formerly known as 'os_boot()'
-  try_context_set(NULL);
-
-  for(;;) {
-    BEGIN_TRY {
-      TRY {
-        // below is a 'manual' implementation of `io_seproxyhal_init`
-        check_api_level(CX_COMPAT_APILEVEL);
-
-        memset(&G_io_app, 0, sizeof(G_io_app));
-
-        G_io_app.apdu_state = APDU_IDLE;
-        G_io_app.apdu_length = 0;
-        G_io_app.apdu_media = IO_APDU_MEDIA_NONE;
-
-        G_io_app.ms = 0;
-        io_usb_hid_init();
-
-        USB_power(0);
-        USB_power(1);
-        sample_main();
-      }
-      CATCH(EXCEPTION_IO_RESET) {
-        continue;
-      }
-      CATCH_ALL {
-        break;
-      }
-      FINALLY {
-      }
-    }
-    END_TRY;
-  }
-  return 0;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,11 +170,6 @@ pub extern "C" fn _start() -> ! {
         bindings::USB_power(1);
     }
 
-    // Required for correct NVM data access
-    unsafe {
-        asm!("mov r9, {}", in(reg) bindings::pic_internal(0xc0d0_0000 as *mut c_void) );
-    }
-
     // Call the 'main' defined in the application
     unsafe {
         sample_main();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod usbbindings;
 
 use bindings::os_sched_exit;
 
+use core::arch::asm;
 use core::{ffi::c_void, panic::PanicInfo};
 
 /// In case of runtime problems, return an internal error and exit the app

--- a/src/seph.rs
+++ b/src/seph.rs
@@ -200,9 +200,14 @@ pub fn handle_usb_ep_xfer_event(apdu_buffer: &mut [u8], buffer: &[u8]) {
                     G_io_app.usb_ep_xfer_len[endpoint as usize] = buffer[5];
                     let mut apdu_buf = ApduBufferT {
                         buf: apdu_buffer.as_mut_ptr(),
-                        len: 260,
+                        len: apdu_buffer.len() as u16,
                     };
-                    USBD_LL_DataOutStage(&mut USBD_Device, endpoint, &buffer[6], &mut apdu_buf);
+                    USBD_LL_DataOutStage(
+                        &mut USBD_Device,
+                        endpoint,
+                        buffer[6..].as_ptr(),
+                        &mut apdu_buf,
+                    );
                 }
             }
         }


### PR DESCRIPTION
- Move boot code from C to Rust
- Remove initial Try/Catch block
- Remove r9-setting hack (not necessary for password-manager rwpi mode anymore)