### PR TITLE
Add new UI gadgets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,12 @@
+[target.nanos]
+runner = "speculos -m nanos --display=headless"
+
+[target.nanox]
+runner = "speculos -m nanox -a 5 --display=headless"
+
+[target.nanosplus]
+runner = "speculos -m nanosp -a 1 --display=headless"
+
 [unstable]
 build-std = ["core"]
 build-std-features = ["compiler-builtins-mem"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,96 +15,66 @@ env:
 
 jobs:
   clippy:
+    name: Run static analysis
     runs-on: ubuntu-latest
-
+    container:
+        image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest
     strategy:
       matrix:
         target: ["nanos", "nanox", "nanosplus"]
-
     steps:
-      - name: arm-none-eabi-gcc
-        uses: fiam/arm-none-eabi-gcc@v1.0.3
-        with:
-          release: '9-2019-q4'
-      - name: Install toolchains
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rust-src, clippy
-      - uses: actions/checkout@v2
+      - name: Clone
+        uses: actions/checkout@v2
       - name: Cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -p ledger_device_rust_sdk --target ledger_device_rust_sdk/${{ matrix.target }}.json
-  fmt:
+          args: -p ledger_device_sdk --target ledger_device_sdk/${{ matrix.target }}.json
+  
+  format:
+    name: Check code formatting
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest
     steps:
-      - name: Install toolchains
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rust-src, rustfmt
-      - uses: actions/checkout@v2
-      - name: Cargo fmt
+      - name: Clone
+        uses: actions/checkout@v2
+      - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: -p ledger_device_rust_sdk --all -- --check
+          args: -p ledger_device_sdk --all -- --check
 
   build:
+    name: Build SDK
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest
     strategy:
       matrix:
         target: ["nanos", "nanox", "nanosplus"]
-
     steps:
-      - name: arm-none-eabi-gcc
-        uses: fiam/arm-none-eabi-gcc@v1.0.3
-        with:
-          release: '9-2019-q4'
-      - name: Install clang
-        run: sudo apt-get update && sudo apt install -y clang
-      - name: Install toolchains
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rust-src
-      - uses: actions/checkout@v2
+      - name: Clone
+        uses: actions/checkout@v2
       - name: Cargo build
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -p ledger_device_rust_sdk --target ledger_device_rust_sdk/${{ matrix.target }}.json
+          args: -p ledger_device_sdk --target ledger_device_sdk/${{ matrix.target }}.json
 
   test:
+    name: Run unit tests
     runs-on: ubuntu-latest
+    container:
+        image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-dev-tools:latest
     strategy:
       matrix:
         target: ["nanos", "nanox", "nanosplus"]
-
     steps:
-      - name: arm-none-eabi-gcc
-        uses: fiam/arm-none-eabi-gcc@v1.0.3
-        with:
-          release: '9-2019-q4'
-      - name: Install clang
-        run: sudo apt-get update && sudo apt install -y clang
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rust-src
-      - name: Install dependencies
-        run: |
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-          pip install speculos --extra-index-url https://test.pypi.org/simple/
-      - uses: actions/checkout@v2
+      - name: Clone
+        uses: actions/checkout@v2
       - name: Unit tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -p ledger_device_rust_sdk --target ledger_device_rust_sdk/${{ matrix.target }}.json --features speculos
+          args: -p ledger_device_sdk --target ledger_device_sdk/${{ matrix.target }}.json --features speculos

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ledger Device Rust SDK
 This workspace contains the 4 crates members of Ledger Device Rust SDK
 
-* [ledger_device_rust_sdk](./ledger_device_rust_sdk): main Rust SDK crate used to build an application that runs on BOLOS OS,
+* [ledger_device_sdk](./ledger_device_sdk): main Rust SDK crate used to build an application that runs on BOLOS OS,
 * [ledger_device_ui_sdk](./ledger_device_ui_sdk): UI SDK used by application to get access to UI gadgets,
 * [ledger_secure_sdk_sys](./ledger_secure_sdk_sys): bindings to [ledger_secure_sdk](https://github.com/LedgerHQ/ledger-secure-sdk)
 * [include_gif](./include_gif): procedural macro used to manage GIF.

--- a/include_gif/src/lib.rs
+++ b/include_gif/src/lib.rs
@@ -1,10 +1,10 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use syn;
 use std;
 use std::fs::File;
 use std::io::Write;
+use syn;
 
 #[proc_macro]
 pub fn include_gif(input: TokenStream) -> TokenStream {
@@ -18,19 +18,19 @@ pub fn include_gif(input: TokenStream) -> TokenStream {
     let palette = decoder.palette().unwrap();
     let dimensions = frame.width * frame.height;
     let (size, remainder) = ((dimensions / 8) as usize, (dimensions % 8) as usize);
-    
+
     let mut packed = Vec::new();
     for i in 0..size {
         let mut byte = 0;
         for j in 0..8 {
-            let color = (palette[frame.buffer[8*i + j] as usize * 3] != 0) as u8;
+            let color = (palette[frame.buffer[8 * i + j] as usize * 3] != 0) as u8;
             byte |= color << j;
         }
         packed.push(byte);
     }
-    let mut byte = 0; 
+    let mut byte = 0;
     for j in 0..remainder {
-        let color = (palette[frame.buffer[8*size + j] as usize * 3] != 0) as u8;
+        let color = (palette[frame.buffer[8 * size + j] as usize * 3] != 0) as u8;
         byte |= color << j;
     }
     packed.push(byte);

--- a/ledger_device_sdk/examples/signature.rs
+++ b/ledger_device_sdk/examples/signature.rs
@@ -8,7 +8,7 @@ fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }
 
-use ledger_device_rust_sdk::ecc::{make_bip32_path, Secp256r1, SeedDerive};
+use ledger_device_sdk::ecc::{make_bip32_path, Secp256r1, SeedDerive};
 
 const PATH: [u32; 5] = make_bip32_path(b"m/44'/123'/0'/0/0");
 

--- a/ledger_device_sdk/src/lib.rs
+++ b/ledger_device_sdk/src/lib.rs
@@ -137,7 +137,8 @@ impl<T> NVMData<T> {
             asm!( "mov {}, r9", out(reg) static_base);
             let offset = (addr - static_base) as isize;
             let data_addr = (_nvram_data as *const u8).offset(offset);
-            let pic_addr = ledger_secure_sdk_sys::pic(data_addr as *mut core::ffi::c_void) as *mut T;
+            let pic_addr =
+                ledger_secure_sdk_sys::pic(data_addr as *mut core::ffi::c_void) as *mut T;
             &mut *pic_addr.cast()
         }
     }

--- a/ledger_device_sdk/src/nvm.rs
+++ b/ledger_device_sdk/src/nvm.rs
@@ -13,8 +13,8 @@
 //! update:
 //!
 //! ```
-//! use ledger_device_rust_sdk::PIC;
-//! use ledger_device_rust_sdk::nvm::AtomicStorage;
+//! use ledger_device_sdk::PIC;
+//! use ledger_device_sdk::nvm::AtomicStorage;
 //!
 //! // This is necessary to store the object in NVM and not in RAM
 //! #[link_section=".nvm_data"]

--- a/ledger_device_ui_sdk/Cargo.toml
+++ b/ledger_device_ui_sdk/Cargo.toml
@@ -7,9 +7,9 @@ license.workspace = true
 description = "Ledger devices abstractions for displaying text, icons, menus and other common gadgets to the screen"
 
 [dependencies]
-ledger_secure_sdk_sys = "1.0.0"
-ledger_device_sdk = "1.0.0"
-include_gif = "1.0.0"
+ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git", branch = "add-ui-gadgets" }
+ledger_secure_sdk_sys = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git", branch = "add-ui-gadgets" }
+include_gif = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git", branch = "add-ui-gadgets" }
 numtoa = "0.2.4"
 
 [features]

--- a/ledger_device_ui_sdk/Cargo.toml
+++ b/ledger_device_ui_sdk/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "ledger_device_ui_sdk"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["yhql"]
 edition = "2021"
 license.workspace = true
 description = "Ledger devices abstractions for displaying text, icons, menus and other common gadgets to the screen"
 
 [dependencies]
-ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git", branch = "add-ui-gadgets" }
-ledger_secure_sdk_sys = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git", branch = "add-ui-gadgets" }
-include_gif = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git", branch = "add-ui-gadgets" }
+ledger_device_sdk = "1.0.0"
+ledger_secure_sdk_sys = "1.0.0"
+include_gif = "1.0.0"
 numtoa = "0.2.4"
 
 [features]

--- a/ledger_device_ui_sdk/Cargo.toml
+++ b/ledger_device_ui_sdk/Cargo.toml
@@ -8,6 +8,7 @@ description = "Ledger devices abstractions for displaying text, icons, menus and
 
 [dependencies]
 ledger_secure_sdk_sys = "1.0.0"
+ledger_device_sdk = "1.0.0"
 include_gif = "1.0.0"
 
 [features]

--- a/ledger_device_ui_sdk/Cargo.toml
+++ b/ledger_device_ui_sdk/Cargo.toml
@@ -10,6 +10,7 @@ description = "Ledger devices abstractions for displaying text, icons, menus and
 ledger_secure_sdk_sys = "1.0.0"
 ledger_device_sdk = "1.0.0"
 include_gif = "1.0.0"
+numtoa = "0.2.4"
 
 [features]
 speculos = []

--- a/ledger_device_ui_sdk/examples/gadgets.rs
+++ b/ledger_device_ui_sdk/examples/gadgets.rs
@@ -118,13 +118,18 @@ extern "C" fn sample_main() {
 
     ui::clear_screen();
 
-    let checkmark = ledger_device_ui_sdk::bagls::CHECKMARK_ICON.set_x(0).set_y(4);
+    let checkmark = ledger_device_ui_sdk::bagls::CHECKMARK_ICON
+        .set_x(0)
+        .set_y(4);
     checkmark.instant_display();
     ledger_device_ui_sdk::bagls::CROSS_ICON
         .set_x(20)
         .set_y(4)
         .instant_display();
-    ledger_device_ui_sdk::bagls::COGGLE.set_x(40).set_y(4).instant_display();
+    ledger_device_ui_sdk::bagls::COGGLE
+        .set_x(40)
+        .set_y(4)
+        .instant_display();
     wait_any();
     checkmark.instant_erase();
     wait_any();

--- a/ledger_device_ui_sdk/examples/gadgets.rs
+++ b/ledger_device_ui_sdk/examples/gadgets.rs
@@ -7,7 +7,7 @@ fn panic(_: &PanicInfo) -> ! {
     loop {}
 }
 
-use ledger_device_rust_sdk::buttons::*;
+use ledger_device_sdk::buttons::*;
 use ledger_device_ui_sdk::layout::{Layout, Location, StringPlace};
 use ledger_device_ui_sdk::ui;
 
@@ -134,5 +134,5 @@ extern "C" fn sample_main() {
     checkmark.instant_erase();
     wait_any();
 
-    ledger_device_rust_sdk::exit_app(0);
+    ledger_device_sdk::exit_app(0);
 }

--- a/ledger_device_ui_sdk/src/bagls/mcu.rs
+++ b/ledger_device_ui_sdk/src/bagls/mcu.rs
@@ -379,12 +379,19 @@ impl<'a> SendToDisplay for Label<'a> {
         };
         let x = match self.layout {
             Layout::RightAligned => self.layout.get_x(self.text.len() * 7),
+            Layout::Custom(x) => x as usize,
             _ => 0,
         };
         let y = self.loc.get_y(self.dims.1 as usize) as i16;
         let width = match self.layout {
             Layout::Centered => crate::SCREEN_WIDTH,
             _ => self.text.len() * 6,
+        };
+        let alignment = match self.layout {
+            Layout::LeftAligned => 0 as u16,
+            Layout::Centered => BAGL_FONT_ALIGNMENT_CENTER as u16,
+            Layout::RightAligned => BAGL_FONT_ALIGNMENT_CENTER as u16,
+            Layout::Custom(_) => 0 as u16,
         };
         let baglcomp = BaglComponent {
             type_: BaglTypes::LabelLine as u8,
@@ -398,7 +405,7 @@ impl<'a> SendToDisplay for Label<'a> {
             fill: 0,
             fgcolor: 0xffffffu32,
             bgcolor: 0,
-            font_id: font_id as u16 | BAGL_FONT_ALIGNMENT_CENTER as u16,
+            font_id: font_id as u16 | alignment,
             icon_id: 0,
         };
 

--- a/ledger_device_ui_sdk/src/bagls/se.rs
+++ b/ledger_device_ui_sdk/src/bagls/se.rs
@@ -73,7 +73,7 @@ use crate::bagls::RectFull;
 
 impl Draw for RectFull {
     fn display(&self) {
-        unsafe { 
+        unsafe {
             ledger_secure_sdk_sys::bagl_hal_draw_rect(
                 1,
                 self.pos.0,
@@ -96,7 +96,6 @@ impl Draw for RectFull {
         }
     }
 }
-
 
 use core::ffi::c_void;
 

--- a/ledger_device_ui_sdk/src/bitmaps.rs
+++ b/ledger_device_ui_sdk/src/bitmaps.rs
@@ -40,15 +40,15 @@ pub fn manual_screen_clear() {
     let inverted = [0u32, 1u32];
     unsafe {
         ledger_secure_sdk_sys::bagl_hal_draw_bitmap_within_rect(
-            0, 
-            0, 
-            128, 
-            64, 
-            2, 
-            inverted.as_ptr(), 
-            1, 
-            BLANK.as_ptr(), 
-            128 * 64
+            0,
+            0,
+            128,
+            64,
+            2,
+            inverted.as_ptr(),
+            1,
+            BLANK.as_ptr(),
+            128 * 64,
         );
     }
 }

--- a/ledger_device_ui_sdk/src/layout.rs
+++ b/ledger_device_ui_sdk/src/layout.rs
@@ -3,6 +3,7 @@ pub enum Layout {
     LeftAligned,
     RightAligned,
     Centered,
+    Custom(usize),
 }
 
 impl Layout {
@@ -11,6 +12,7 @@ impl Layout {
             Layout::LeftAligned => crate::PADDING,
             Layout::Centered => (crate::SCREEN_WIDTH - width) / 2,
             Layout::RightAligned => crate::SCREEN_WIDTH - crate::PADDING - width,
+            Layout::Custom(x) => *x,
         }
     }
 }
@@ -26,9 +28,9 @@ pub enum Location {
 impl Location {
     pub fn get_y(&self, height: usize) -> usize {
         match self {
-            Location::Top => 0,
+            Location::Top => crate::Y_PADDING,
             Location::Middle => (crate::SCREEN_HEIGHT - height) / 2,
-            Location::Bottom => crate::SCREEN_HEIGHT - height,
+            Location::Bottom => crate::SCREEN_HEIGHT - height - crate::Y_PADDING,
             Location::Custom(y) => *y,
         }
     }

--- a/ledger_device_ui_sdk/src/lib.rs
+++ b/ledger_device_ui_sdk/src/lib.rs
@@ -18,6 +18,7 @@ pub mod screen_util;
 pub mod ui;
 
 pub const PADDING: usize = 2;
+pub const Y_PADDING: usize = 3;
 pub const SCREEN_WIDTH: usize = 128;
 
 #[cfg(target_os = "nanos")]

--- a/ledger_device_ui_sdk/src/screen_util.rs
+++ b/ledger_device_ui_sdk/src/screen_util.rs
@@ -6,15 +6,16 @@ pub fn draw(x_pos: i32, y_pos: i32, w: u32, h: u32, inv: bool, bmp: &[u8]) {
     let inverted = [inv as u32, !inv as u32];
     unsafe {
         ledger_secure_sdk_sys::bagl_hal_draw_bitmap_within_rect(
-            x_pos, 
-            y_pos, 
-            w, 
-            h, 
-            2, 
-            inverted.as_ptr(), 
-            1, 
-            bmp.as_ptr(), 
-            w * h);
+            x_pos,
+            y_pos,
+            w,
+            h,
+            2,
+            inverted.as_ptr(),
+            1,
+            bmp.as_ptr(),
+            w * h,
+        );
     }
 }
 

--- a/ledger_device_ui_sdk/src/string_se.rs
+++ b/ledger_device_ui_sdk/src/string_se.rs
@@ -11,9 +11,12 @@ extern "C" {
 impl StringPlace for &str {
     fn compute_width(&self, bold: bool) -> usize {
         let font_choice = bold as usize;
-        self.as_bytes().iter().map(ledger_secure_sdk_sys::pic_rs).fold(0, |acc, c| {
-            acc + OPEN_SANS[font_choice].dims[*c as usize - 0x20] as usize
-        })
+        self.as_bytes()
+            .iter()
+            .map(ledger_secure_sdk_sys::pic_rs)
+            .fold(0, |acc, c| {
+                acc + OPEN_SANS[font_choice].dims[*c as usize - 0x20] as usize
+            })
     }
 
     fn place(&self, loc: Location, layout: Layout, bold: bool) {

--- a/ledger_device_ui_sdk/src/string_se.rs
+++ b/ledger_device_ui_sdk/src/string_se.rs
@@ -52,7 +52,7 @@ impl StringPlace for [&str] {
 
     fn place(&self, loc: Location, layout: Layout, bold: bool) {
         let c_height = OPEN_SANS[bold as usize].height as usize;
-        let padding = if self.len() > 4 { 0 } else { 2 };
+        let padding = if self.len() > 4 { 0 } else { 1 };
         let total_height = self.len() * (c_height + padding);
         let mut cur_y = loc.get_y(total_height);
         for string in self.iter() {

--- a/ledger_device_ui_sdk/src/ui.rs
+++ b/ledger_device_ui_sdk/src/ui.rs
@@ -497,17 +497,10 @@ impl<'a> MultiPageMenu<'a> {
             match self.comm.next_event() {
                 io::Event::Button(button) => {
                     match button {
-                        LeftButtonPress => {
-                            LEFT_S_ARROW.instant_display();
-                        }
-                        RightButtonPress => {
-                            RIGHT_S_ARROW.instant_display();
-                        }
                         BothButtonsRelease => return EventOrPageIndex::Index(index), 
                         b => {
                             match b {
                                 LeftButtonRelease => {
-                                    LEFT_S_ARROW.erase();
                                     if index as i16 - 1 < 0 {
                                         index = self.pages.len() - 1;
                                     } else {
@@ -515,7 +508,6 @@ impl<'a> MultiPageMenu<'a> {
                                     }
                                 }
                                 RightButtonRelease => {
-                                    RIGHT_S_ARROW.erase();
                                     if index < self.pages.len() - 1 {
                                         index += 1;
                                     } else {
@@ -751,16 +743,6 @@ impl<'a> MultiFieldReview<'a> {
 
         loop {
             match get_event(&mut buttons) {
-                Some(ButtonEvent::LeftButtonPress) => {
-                    if cur_page > 0 {
-                        LEFT_S_ARROW.instant_display();
-                    }
-                }
-                Some(ButtonEvent::RightButtonPress) => {
-                    if cur_page < total_page_count {
-                        RIGHT_S_ARROW.instant_display();
-                    }
-                }
                 Some(b) => {
                     match b {
                         ButtonEvent::LeftButtonRelease => {


### PR DESCRIPTION
Add two new UI gadgets : 

* `MultiPageMenu` to display menus with pages that can have various styles : 
    - PictureNormal : Picture (should be 16x16) with two lines of text (page layout depends on device).
    - PictureBold : Icon on top with one line of text on the bottom.
    - BoldNormal : One line of bold text and one line of normal text on Nano S or up to 3 lines on Nano X/SP.
    - Normal : 2 lines of centered text.
 
  `MultiPageMenu` `new` function takes an `io::comm` as parameter so its `show` function can return a page index (in case of user "both button press") or any other event upon reception. It allows for any APDU to be received and processed when a menu is displayed.

* `MultiFieldReview` to review multiple fields with a review message at the start and validation/cancel messages at the end. The `show` function returns a boolean upon validation/cancellation by the user.