### PR TITLE
Improvements in commands parsing support

### DIFF
--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_device_sdk"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["yhql", "yogh333"]
 edition = "2021"
 license.workspace = true

--- a/ledger_device_sdk/src/io.rs
+++ b/ledger_device_sdk/src/io.rs
@@ -305,6 +305,12 @@ impl Comm {
                 return None;
             }
 
+            // Check for data length by using `get_data`
+            if let Err(sw) = self.get_data() {
+                self.reply(sw);
+                return None;
+            }
+
             let res = T::try_from(*self.get_apdu_metadata());
             match res {
                 Ok(ins) => {

--- a/ledger_device_sdk/src/ui/gadgets.rs
+++ b/ledger_device_sdk/src/ui/gadgets.rs
@@ -2,7 +2,10 @@
 
 use core::str::from_utf8;
 
-use crate::{buttons::ButtonEvent::*, io};
+use crate::{
+    buttons::ButtonEvent::*,
+    io::{self, ApduHeader, Reply},
+};
 use ledger_secure_sdk_sys::{
     buttons::{get_button_event, ButtonEvent, ButtonsState},
     seph,
@@ -491,8 +494,8 @@ impl<'a> Page<'a> {
     }
 }
 
-pub enum EventOrPageIndex {
-    Event(io::Event<io::ApduHeader>),
+pub enum EventOrPageIndex<T> {
+    Event(io::Event<T>),
     Index(usize),
 }
 
@@ -506,7 +509,10 @@ impl<'a> MultiPageMenu<'a> {
         MultiPageMenu { comm, pages }
     }
 
-    pub fn show(&mut self) -> EventOrPageIndex {
+    pub fn show<T: TryFrom<ApduHeader>>(&mut self) -> EventOrPageIndex<T>
+    where
+        Reply: From<<T as TryFrom<ApduHeader>>::Error>,
+    {
         clear_screen();
 
         self.pages[0].place();

--- a/ledger_device_sdk/src/uxapp.rs
+++ b/ledger_device_sdk/src/uxapp.rs
@@ -1,6 +1,7 @@
 use ledger_secure_sdk_sys::seph as sys_seph;
 use ledger_secure_sdk_sys::*;
 
+use crate::io::Reply;
 use crate::io::{ApduHeader, Comm, Event};
 
 pub use ledger_secure_sdk_sys::BOLOS_UX_CANCEL;
@@ -66,7 +67,11 @@ impl UxEvent {
         ret
     }
 
-    pub fn block_and_get_event<T: TryFrom<ApduHeader>>(comm: &mut Comm) -> (u32, Option<Event<T>>) {
+    pub fn block_and_get_event<T>(comm: &mut Comm) -> (u32, Option<Event<T>>)
+    where
+        T: TryFrom<ApduHeader>,
+        Reply: From<<T as TryFrom<ApduHeader>>::Error>,
+    {
         let mut ret = unsafe { os_sched_last_status(TASK_BOLOS_UX as u32) } as u32;
         let mut event = None;
         while ret == BOLOS_UX_IGNORE || ret == BOLOS_UX_CONTINUE {


### PR DESCRIPTION
Translation from an `ApduHeader` to a custom command type can now return different status words, which are then automatically sent as reply to the host by the SDK.

This allows to implement complex parsing logic which may return appropriate error status words depending on which APDU header fields are invalid (invalid class, invalid instruction, bad P1 or P2, etc.).

Added a check to reject automatically too short APDUs, so SDK users don't have to do this check in the app code.