### PR TITLE
Fix/publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,11 +82,11 @@ jobs:
         id: check-version
         run: |
           PACKAGE_NAME="${{ steps.determine-package.outputs.package }}"
-          TAG_VERSION=$(echo "${{ github.ref }}" | cut -d 'v' -f 2)
+          TAG_VERSION=$(echo "${{ github.ref }}" | rev | cut -d 'v' -f 1 | rev)
           MANIFEST_VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r --arg PACKAGE_NAME "$PACKAGE_NAME" '.packages[] | select(.name == $PACKAGE_NAME) | .version')
 
           if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
-            echo "Package version in manifest does not match tag version."
+            echo "Package version in manifest $MANIFEST_VERSION does not match tag version $TAG_VERSION."
             exit 1
           else
             echo "Package version in manifest matches tag version."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           # Extract package name from the tag name
           TAG_NAME="${{ github.ref }}"
-          PACKAGE_NAME=$(echo "$TAG_NAME" | cut -d'-' -f1)
+          PACKAGE_NAME=$(echo "$TAG_NAME" | cut -d'/' -f3 | cut -d'-' -f1)
 
           PACKAGE_NAMES=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[].name' | tr '\n' ' ')
 


### PR DESCRIPTION
slight modification in the publish workflow.

To publish a crate, it has to be tagged as following <package_name>**-vx.y.z**, where x.y.z shall match the version in the crate's Cargo.toml. 