### PR TITLE
Added display_pending_review method

### DIFF
--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_device_sdk"
-version = "1.2.1"
+version = "1.3.0"
 authors = ["yhql", "yogh333"]
 edition = "2021"
 license.workspace = true

--- a/ledger_device_sdk/src/io.rs
+++ b/ledger_device_sdk/src/io.rs
@@ -78,7 +78,7 @@ impl From<SyscallError> for Reply {
 // `Error` as `Infallible`. Since we need to convert such error in a status word (`Reply`) we need
 // to implement this trait here.
 impl From<Infallible> for Reply {
-    fn from(value: Infallible) -> Self {
+    fn from(_value: Infallible) -> Self {
         Reply(0x9000)
     }
 }

--- a/ledger_device_sdk/src/ui/gadgets.rs
+++ b/ledger_device_sdk/src/ui/gadgets.rs
@@ -73,6 +73,42 @@ pub fn popup(message: &str) {
     SingleMessage::new(message).show_and_wait();
 }
 
+/// Display a developer mode / pending review popup, cleared with user interaction.
+///
+/// This method must be called by an application at the very beginning until it has been reviewed
+/// and approved by Ledger.
+///
+/// # Arguments
+///
+/// * `comm` - Communication manager used to get device events.
+///
+/// # Examples
+///
+/// Following is an application example main function calling the pending review popup at the very
+/// beginning, before doing any other application logic.
+///
+/// ```
+/// #[no_mangle]
+/// extern "C" fn sample_main() {
+///     let mut comm = Comm::new();
+///     ledger_device_sdk::ui::gadgets::display_pending_review(&mut comm);
+///     ...
+/// }
+/// ```
+pub fn display_pending_review(comm: &mut io::Comm) {
+    clear_screen();
+    "Pending Review".place(Location::Middle, Layout::Centered, false);
+    crate::ui::screen_util::screen_update();
+
+    loop {
+        if let io::Event::Button(LeftButtonRelease | RightButtonRelease | BothButtonsRelease) =
+            comm.next_event::<ApduHeader>()
+        {
+            break;
+        }
+    }
+}
+
 /// Display a single screen with a message,
 /// and exit the function with 'true'
 /// if the user validated 'message'


### PR DESCRIPTION
Added new display_pending_review method in the UI, to be called at the beginning of applications which have not been reviewed yet. This avoids having this code in the boilerplate application, and being duplicated.