### PR TITLE
Added automatic CLA filtering option in Comm

### DIFF
--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_device_sdk"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["yhql", "yogh333"]
 edition = "2021"
 license.workspace = true

--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_device_sdk"
-version = "1.2.1"
+version = "1.3.0"
 authors = ["yhql", "yogh333"]
 edition = "2021"
 license.workspace = true

--- a/ledger_device_sdk/src/io.rs
+++ b/ledger_device_sdk/src/io.rs
@@ -112,7 +112,7 @@ pub struct Comm {
     /// Expected value for the APDU CLA byte.
     /// If defined, [`Comm`] will automatically reply with [`StatusWords::BadCla`] when an APDU
     /// with wrong CLA byte is received. If set to [`None`], all CLA are accepted.
-    /// Can be set using [`Comm::expect_cla`] method.
+    /// Can be set using [`Comm::set_expected_cla`] method.
     pub expected_cla: Option<u8>,
 }
 
@@ -159,9 +159,9 @@ impl Comm {
     /// This method can be used when building an instance of [`Comm`]:
     ///
     /// ```
-    /// let mut comm = Comm::new().expect_cla(0xe0);
+    /// let mut comm = Comm::new().set_expected_cla(0xe0);
     /// ```
-    pub fn expect_cla(mut self, cla: u8) -> Self {
+    pub fn set_expected_cla(mut self, cla: u8) -> Self {
         self.expected_cla = Some(cla);
         self
     }

--- a/ledger_device_sdk/src/io.rs
+++ b/ledger_device_sdk/src/io.rs
@@ -102,11 +102,18 @@ pub enum Event<T> {
     Ticker,
 }
 
+/// Manages the communication of the device: receives events such as button presses, incoming
+/// APDU requests, and provides methods to build and transmit APDU responses.
 pub struct Comm {
     pub apdu_buffer: [u8; 260],
     pub rx: usize,
     pub tx: usize,
     buttons: ButtonsState,
+    /// Expected value for the APDU CLA byte.
+    /// If defined, [`Comm`] will automatically reply with [`StatusWords::BadCla`] when an APDU
+    /// with wrong CLA byte is received. If set to [`None`], all CLA are accepted.
+    /// Can be set using [`Comm::expect_cla`] method.
+    pub expected_cla: Option<u8>,
 }
 
 impl Default for Comm {
@@ -129,13 +136,34 @@ pub struct ApduHeader {
 }
 
 impl Comm {
+    /// Creates a new [`Comm`] instance, which accepts any CLA APDU by default.
     pub const fn new() -> Self {
         Self {
             apdu_buffer: [0u8; 260],
             rx: 0,
             tx: 0,
             buttons: ButtonsState::new(),
+            expected_cla: None,
         }
+    }
+
+    /// Defines [`Comm::expected_cla`] in order to reply automatically [`StatusWords::BadCla`] when
+    /// an incoming APDU has a CLA byte different from the given value.
+    ///
+    /// # Arguments
+    ///
+    /// * `cla` - Expected value for APDUs CLA byte.
+    ///
+    /// # Examples
+    ///
+    /// This method can be used when building an instance of [`Comm`]:
+    ///
+    /// ```
+    /// let mut comm = Comm::new().expect_cla(0xe0);
+    /// ```
+    pub fn expect_cla(mut self, cla: u8) -> Self {
+        self.expected_cla = Some(cla);
+        self
     }
 
     /// Send the currently held APDU
@@ -309,6 +337,14 @@ impl Comm {
             if let Err(sw) = self.get_data() {
                 self.reply(sw);
                 return None;
+            }
+
+            // If CLA filtering is enabled, automatically reject APDUs with wrong CLA
+            if let Some(cla) = self.expected_cla {
+                if self.apdu_buffer[0] != cla {
+                    self.reply(StatusWords::BadCla);
+                    return None;
+                }
             }
 
             let res = T::try_from(*self.get_apdu_metadata());


### PR DESCRIPTION
Most of the applications check for the value of CLA byte of incoming APDUs and return an error status word when it is different from a constant.

This feature can help simplifying apps by removing the need to handle bad CLA errors, as there is not added value by the apps in dealing with this.