### PR TITLE
rework MultiFieldReview to use less stack

### DIFF
--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_device_sdk"
-version = "1.4.2"
+version = "1.4.3"
 authors = ["yhql", "yogh333"]
 edition = "2021"
 license.workspace = true

--- a/ledger_device_sdk/examples/gadgets.rs
+++ b/ledger_device_sdk/examples/gadgets.rs
@@ -4,7 +4,7 @@
 use core::panic::PanicInfo;
 #[panic_handler]
 fn panic(_: &PanicInfo) -> ! {
-    loop {}
+    ledger_device_sdk::exit_app(1);
 }
 
 use ledger_device_sdk::buttons::*;

--- a/ledger_device_sdk/examples/review.rs
+++ b/ledger_device_sdk/examples/review.rs
@@ -1,0 +1,40 @@
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+#[panic_handler]
+fn panic(_: &PanicInfo) -> ! {
+    ledger_device_sdk::exit_app(1);
+}
+
+use ledger_device_sdk::ui::bitmaps::*;
+use ledger_device_sdk::ui::gadgets::{Field, MultiFieldReview};
+
+#[no_mangle]
+extern "C" fn sample_main() {
+    let fields = [
+            Field {
+                name: "Amount",
+                value: "CRAB 666",
+            },
+            Field {
+                name: "Destination",
+                value: "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae",
+            },
+            Field {
+                name: "Memo",
+                value: "This is a very long memo. It will force the app client to send the serialized transaction to be sent in chunk. As the maximum chunk size is 255 bytes we will make this memo greater than 255 characters. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. Cras elementum ultrices diam.",
+            },
+    ];
+    let review = MultiFieldReview::new(
+        &fields,
+        &["Review ", "Transaction"],
+        Some(&EYE),
+        "Approve",
+        Some(&VALIDATE_14),
+        "Reject",
+        Some(&CROSSMARK),
+    );
+    review.show();
+    ledger_device_sdk::exit_app(0);
+}

--- a/ledger_device_sdk/src/ui/bagls/mcu.rs
+++ b/ledger_device_sdk/src/ui/bagls/mcu.rs
@@ -134,12 +134,25 @@ pub enum Font {
     Symbols1,
 }
 
+#[derive(Clone, Copy)]
 pub struct Label<'a> {
     pub loc: Location,
     pub layout: Layout,
     pub dims: (u16, u16),
     pub bold: bool,
     pub text: &'a str,
+}
+
+impl Default for Label<'_> {
+    fn default() -> Self {
+        Label {
+            text: "",
+            bold: false,
+            dims: (128, 11),
+            loc: Location::Middle,
+            layout: Layout::Centered,
+        }
+    }
 }
 
 impl<'a> Label<'a> {

--- a/ledger_device_sdk/src/ui/bagls/se.rs
+++ b/ledger_device_sdk/src/ui/bagls/se.rs
@@ -3,11 +3,23 @@ use crate::ui::fonts::OPEN_SANS;
 use crate::ui::layout::*;
 use ledger_secure_sdk_sys;
 
+#[derive(Clone, Copy)]
 pub struct Label<'a> {
     pub text: &'a str,
     pub bold: bool,
     pub loc: Location,
     layout: Layout,
+}
+
+impl Default for Label<'_> {
+    fn default() -> Self {
+        Label {
+            text: "",
+            bold: false,
+            loc: Location::Middle,
+            layout: Layout::Centered,
+        }
+    }
 }
 
 impl<'a> From<&'a str> for Label<'a> {

--- a/ledger_device_sdk/src/ui/layout.rs
+++ b/ledger_device_sdk/src/ui/layout.rs
@@ -40,7 +40,7 @@ impl Location {
 pub const MAX_LINES: usize = 2;
 
 #[cfg(not(target_os = "nanos"))]
-pub const MAX_LINES: usize = 3;
+pub const MAX_LINES: usize = 4;
 
 pub trait Place {
     fn place_pad(&self, loc: Location, layout: Layout, padding: i32);


### PR DESCRIPTION
Preallocating 48 Pages led to a huge stack usage and to crashes on Nano S. 
This gadget was reworked so that it does not preallocate, and makes it "simpler" to visualize Fields by giving them their own widget (similar to MessageScroller in behaviour, except with a counter and a different amount of lines used).

Note that `MAX_LINES` was changed to `4` (was previously `3`) for Nano X/S+ to avoid ifdefs to match the C version of the Field view, but as a consequence, a Menu now displays over 4 lines.