### PR TITLE
Update shlex from 1.2.0 to 1.3.0 (security update)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"


### PR DESCRIPTION
See more details [here](https://github.com/LedgerHQ/ledger-device-rust-sdk/security/dependabot/1)