### PR TITLE
[ledger_device_sdk] Bump version 1.7.0

### DIFF
--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_device_sdk"
-version = "1.6.0"
+version = "1.7.0"
 authors = ["yhql", "yogh333"]
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
Bump new version for ledger_device_sdk after merging:

- PR #139
- PR #135 