### PR TITLE
Save stack during eddsa streaming

### DIFF
--- a/ledger_device_sdk/src/ecc.rs
+++ b/ledger_device_sdk/src/ecc.rs
@@ -315,7 +315,8 @@ impl Ed25519Stream {
         // Compute prefix (see https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.6, step 1)
         let mut res = Ed25519Stream::default();
         let mut temp = Secret::<64>::new();
-        res.hash.hash(&key.key[..], temp.as_mut())
+        res.hash
+            .hash(&key.key[..], temp.as_mut())
             .map_err(|_| CxError::GenericError)?;
         res.hash = Sha2_512::new();
         res.hash

--- a/ledger_device_sdk/src/hash.rs
+++ b/ledger_device_sdk/src/hash.rs
@@ -67,7 +67,7 @@ pub trait HashInit: Sized {
             Ok(())
         }
     }
-    fn finalize(mut self, output: &mut [u8]) -> Result<(), HashError> {
+    fn finalize(&mut self, output: &mut [u8]) -> Result<(), HashError> {
         let output_size = self.get_size();
         if output_size > output.len() {
             return Err(HashError::InvalidOutputLength);
@@ -107,7 +107,7 @@ macro_rules! impl_hash {
     };
 
     ($typename:ident, $ctxname:ident, $initfname:ident) => {
-        #[derive(Copy, Clone, Default)]
+        #[derive(Default)]
         #[allow(non_camel_case_types)]
         pub struct $typename {
             ctx: $ctxname,

--- a/ledger_device_sdk/src/hash.rs
+++ b/ledger_device_sdk/src/hash.rs
@@ -37,7 +37,7 @@ pub trait HashInit: Sized {
     fn get_size(&mut self) -> usize {
         unsafe { cx_hash_get_size(self.as_ctx()) }
     }
-    fn hash(mut self, input: &[u8], output: &mut [u8]) -> Result<(), HashError> {
+    fn hash(&mut self, input: &[u8], output: &mut [u8]) -> Result<(), HashError> {
         let output_size = self.get_size();
         if output_size > output.len() {
             return Err(HashError::InvalidOutputLength);
@@ -84,7 +84,7 @@ pub trait HashInit: Sized {
 
 macro_rules! impl_hash {
     ($typename:ident, $ctxname:ident, $initfname:ident, $size:expr) => {
-        #[derive(Copy, Clone, Default)]
+        #[derive(Default)]
         #[allow(non_camel_case_types)]
         pub struct $typename {
             ctx: $ctxname,


### PR DESCRIPTION
- Remove useless StreamInit struct and provide a `new()` to Stream instead
- Use the ed25519's default hash as temporary during new/init
- Avoid making Hash copyable, fix a method that takes `mut self` instead of `&mut self` and induced copies
