### PR TITLE
Eddsa streaming stack savings again

### DIFF
--- a/ledger_device_sdk/src/hash.rs
+++ b/ledger_device_sdk/src/hash.rs
@@ -34,6 +34,7 @@ pub trait HashInit: Sized {
     fn as_ctx_mut(&mut self) -> &mut cx_hash_t;
     fn as_ctx(&self) -> &cx_hash_t;
     fn new() -> Self;
+    fn reset(&mut self);
     fn get_size(&mut self) -> usize {
         unsafe { cx_hash_get_size(self.as_ctx()) }
     }
@@ -103,6 +104,10 @@ macro_rules! impl_hash {
                 let _err = unsafe { $initfname(&mut ctx.ctx, $size) };
                 ctx
             }
+
+            fn reset(&mut self) {
+                let _err = unsafe { $initfname(&mut self.ctx, $size) };
+            }
         }
     };
 
@@ -125,6 +130,10 @@ macro_rules! impl_hash {
                 let mut ctx: $typename = Default::default();
                 let _err = unsafe { $initfname(&mut ctx.ctx) };
                 ctx
+            }
+
+            fn reset(&mut self) {
+                let _err = unsafe { $initfname(&mut self.ctx) };
             }
         }
     };


### PR DESCRIPTION
- Avoid a copy in big_r.into_iter
- Use a `reset` function to reinitialize hash state instead of recreating a whole Sha2_512 on stack
- Split the "compute r" and "compute s" parts of finalize for easier stack tracking