### PR TITLE
updates `HEAP_SIZE` to be configurable for `embedded alloc`

### DIFF
--- a/ledger_secure_sdk_sys/build.rs
+++ b/ledger_secure_sdk_sys/build.rs
@@ -1,5 +1,6 @@
 extern crate cc;
 use glob::glob;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs::File, io::BufRead, io::BufReader, io::Read};
@@ -575,6 +576,17 @@ impl SDKBuilder {
             .write_to_file(out_path.join("bindings.rs"))
             .expect("Couldn't write bindings");
     }
+
+    fn generate_heap_size(&self) {
+        // Read the HEAP_SIZE environment variable, default to 8192 if not set
+        let heap_size = env::var("HEAP_SIZE").unwrap_or_else(|_| "8192".to_string());
+
+        // Generate the heap_size.rs file with the HEAP_SIZE value
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let dest_path = Path::new(&out_dir).join("heap_size.rs");
+        fs::write(&dest_path, format!("pub const HEAP_SIZE: usize = {};", heap_size))
+            .expect("Unable to write file");
+    }
 }
 
 fn main() {
@@ -585,6 +597,7 @@ fn main() {
     sdk_builder.cxdefines();
     sdk_builder.build_c_sdk();
     sdk_builder.generate_bindings();
+    sdk_builder.generate_heap_size();
 }
 
 fn finalize_nanos_configuration(command: &mut cc::Build, bolos_sdk: &Path) {

--- a/ledger_secure_sdk_sys/src/lib.rs
+++ b/ledger_secure_sdk_sys/src/lib.rs
@@ -63,7 +63,7 @@ unsafe impl critical_section::Impl for CriticalSection {
 #[no_mangle]
 #[cfg(feature = "heap")]
 extern "C" fn heap_init() {
-    const HEAP_SIZE: usize = 8192;
+    // HEAP_SIZE comes from heap_size.rs, which is defined via env var and build.rs
     static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
     unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
 }
@@ -73,3 +73,4 @@ extern "C" fn heap_init() {
 extern "C" fn heap_init() {}
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+include!(concat!(env!("OUT_DIR"), "/heap_size.rs"));


### PR DESCRIPTION
This should be optionally configurable as it is possible to use more than 8KB memory on device.