### PR TITLE
Allow heap feature to be disabled.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "ledger_device_sdk"
-version = "1.13.1"
+version = "1.14.0"
 dependencies = [
  "const-zero",
  "include_gif",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "ledger_device_sdk"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "const-zero",
  "include_gif",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "ledger_secure_sdk_sys"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "bindgen",
  "cc",

--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -21,13 +21,11 @@ rand_core = { version = "0.6.3", default_features = false }
 zeroize = { version = "1.6.0", default_features = false }
 numtoa = "0.2.4"
 const-zero = "0.1.1"
-
-[target.'cfg(target_os="nanos")'.dependencies]
-ledger_secure_sdk_sys = {path = "../ledger_secure_sdk_sys", version = "1.4.3"}
-
-[target.'cfg(not(target_os="nanos"))'.dependencies]
-ledger_secure_sdk_sys = {path = "../ledger_secure_sdk_sys", version = "1.4.3", features = ["heap"]}
+ledger_secure_sdk_sys = {path = "../ledger_secure_sdk_sys", version = "1.4.3", default_features = false}
 
 [features]
 speculos = []
 ccid = []
+heap = [ "ledger_secure_sdk_sys/heap" ]
+
+default = [ "heap" ]

--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_device_sdk"
-version = "1.14.0"
+version = "1.14.1"
 authors = ["yhql", "yogh333", "agrojean-ledger", "kingofpayne"]
 edition = "2021"
 license.workspace = true
@@ -21,7 +21,7 @@ rand_core = { version = "0.6.3", default_features = false }
 zeroize = { version = "1.6.0", default_features = false }
 numtoa = "0.2.4"
 const-zero = "0.1.1"
-ledger_secure_sdk_sys = { path = "../ledger_secure_sdk_sys", version = "1.4.3" }
+ledger_secure_sdk_sys = { path = "../ledger_secure_sdk_sys", version = "1.4.4" }
 
 [features]
 speculos = []

--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -21,7 +21,7 @@ rand_core = { version = "0.6.3", default_features = false }
 zeroize = { version = "1.6.0", default_features = false }
 numtoa = "0.2.4"
 const-zero = "0.1.1"
-ledger_secure_sdk_sys = {path = "../ledger_secure_sdk_sys", version = "1.4.3", default_features = false}
+ledger_secure_sdk_sys = { path = "../ledger_secure_sdk_sys", version = "1.4.3" }
 
 [features]
 speculos = []

--- a/ledger_secure_sdk_sys/Cargo.toml
+++ b/ledger_secure_sdk_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_secure_sdk_sys"
-version = "1.4.3"
+version = "1.4.4"
 authors = ["yhql", "agrojean-ledger"]
 edition = "2021"
 license.workspace = true

--- a/ledger_secure_sdk_sys/src/lib.rs
+++ b/ledger_secure_sdk_sys/src/lib.rs
@@ -63,7 +63,7 @@ unsafe impl critical_section::Impl for CriticalSection {
 #[no_mangle]
 #[cfg(all(feature = "heap", not(target_os = "nanos")))]
 extern "C" fn heap_init() {
-    const HEAP_SIZE: usize = 1024;
+    const HEAP_SIZE: usize = 8192;
     static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
     unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
 }

--- a/ledger_secure_sdk_sys/src/lib.rs
+++ b/ledger_secure_sdk_sys/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(non_snake_case)]
 
 use core::ffi::c_void;
-#[cfg(all(feature = "heap", not(target_os="nanos")))]
+#[cfg(all(feature = "heap", not(target_os = "nanos")))]
 use core::mem::MaybeUninit;
 
 pub mod buttons;
@@ -35,22 +35,22 @@ pub fn pic_rs_mut<T>(x: &mut T) -> &mut T {
     unsafe { &mut *ptr }
 }
 
-#[cfg(all(feature = "heap", not(target_os="nanos")))]
+#[cfg(all(feature = "heap", not(target_os = "nanos")))]
 use critical_section::RawRestoreState;
-#[cfg(all(feature = "heap", not(target_os="nanos")))]
+#[cfg(all(feature = "heap", not(target_os = "nanos")))]
 use embedded_alloc::Heap;
 
-#[cfg(all(feature = "heap", not(target_os="nanos")))]
+#[cfg(all(feature = "heap", not(target_os = "nanos")))]
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 
-#[cfg(all(feature = "heap", not(target_os="nanos")))]
+#[cfg(all(feature = "heap", not(target_os = "nanos")))]
 struct CriticalSection;
-#[cfg(all(feature = "heap", not(target_os="nanos")))]
+#[cfg(all(feature = "heap", not(target_os = "nanos")))]
 critical_section::set_impl!(CriticalSection);
 
 /// Default empty implementation as we don't have concurrency.
-#[cfg(all(feature = "heap", not(target_os="nanos")))]
+#[cfg(all(feature = "heap", not(target_os = "nanos")))]
 unsafe impl critical_section::Impl for CriticalSection {
     unsafe fn acquire() -> RawRestoreState {}
     unsafe fn release(_restore_state: RawRestoreState) {}
@@ -61,7 +61,7 @@ unsafe impl critical_section::Impl for CriticalSection {
 /// The heap is stored in the stack, and has a fixed size.
 /// This method is called just before [sample_main].
 #[no_mangle]
-#[cfg(all(feature = "heap", not(target_os="nanos")))]
+#[cfg(all(feature = "heap", not(target_os = "nanos")))]
 extern "C" fn heap_init() {
     const HEAP_SIZE: usize = 1024;
     static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
@@ -69,7 +69,7 @@ extern "C" fn heap_init() {
 }
 
 #[no_mangle]
-#[cfg(any(not(feature = "heap"), target_os="nanos"))]
+#[cfg(any(not(feature = "heap"), target_os = "nanos"))]
 extern "C" fn heap_init() {}
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/ledger_secure_sdk_sys/src/lib.rs
+++ b/ledger_secure_sdk_sys/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(non_snake_case)]
 
 use core::ffi::c_void;
-#[cfg(feature = "heap")]
+#[cfg(all(feature = "heap", not(target_os="nanos")))]
 use core::mem::MaybeUninit;
 
 pub mod buttons;
@@ -35,22 +35,22 @@ pub fn pic_rs_mut<T>(x: &mut T) -> &mut T {
     unsafe { &mut *ptr }
 }
 
-#[cfg(feature = "heap")]
+#[cfg(all(feature = "heap", not(target_os="nanos")))]
 use critical_section::RawRestoreState;
-#[cfg(feature = "heap")]
+#[cfg(all(feature = "heap", not(target_os="nanos")))]
 use embedded_alloc::Heap;
 
-#[cfg(feature = "heap")]
+#[cfg(all(feature = "heap", not(target_os="nanos")))]
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 
-#[cfg(feature = "heap")]
+#[cfg(all(feature = "heap", not(target_os="nanos")))]
 struct CriticalSection;
-#[cfg(feature = "heap")]
+#[cfg(all(feature = "heap", not(target_os="nanos")))]
 critical_section::set_impl!(CriticalSection);
 
 /// Default empty implementation as we don't have concurrency.
-#[cfg(feature = "heap")]
+#[cfg(all(feature = "heap", not(target_os="nanos")))]
 unsafe impl critical_section::Impl for CriticalSection {
     unsafe fn acquire() -> RawRestoreState {}
     unsafe fn release(_restore_state: RawRestoreState) {}
@@ -61,15 +61,15 @@ unsafe impl critical_section::Impl for CriticalSection {
 /// The heap is stored in the stack, and has a fixed size.
 /// This method is called just before [sample_main].
 #[no_mangle]
-#[cfg(feature = "heap")]
+#[cfg(all(feature = "heap", not(target_os="nanos")))]
 extern "C" fn heap_init() {
-    const HEAP_SIZE: usize = 8192;
+    const HEAP_SIZE: usize = 1024;
     static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
     unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
 }
 
 #[no_mangle]
-#[cfg(not(feature = "heap"))]
+#[cfg(any(not(feature = "heap"), target_os="nanos"))]
 extern "C" fn heap_init() {}
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
A while back the SDK introduced a heap allocator for everything but the `nanos`, which uses a config trick to enable this for all other platforms, however, the large size chosen for this default heap may exceed the available memory for applications that are already near RAM limits, and the target specific inclusion trick used to select this does not allow the heap feature to be disabled.

This PR simplifies the behaviour of the `heap` feature so this has no effect on the unsupported `nanos` target and can be disabled for apps that need to control the size of the allocated heap.
