### PR TITLE
Enable QR code library in C SDK bindings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "ledger_secure_sdk_sys"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "ledger_device_sdk"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "const-zero",
  "include_gif",

--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_device_sdk"
-version = "1.15.0"
+version = "1.15.1"
 authors = ["yhql", "yogh333", "agrojean-ledger", "kingofpayne"]
 edition = "2021"
 license.workspace = true
@@ -21,7 +21,7 @@ rand_core = { version = "0.6.3", default_features = false }
 zeroize = { version = "1.6.0", default_features = false }
 numtoa = "0.2.4"
 const-zero = "0.1.1"
-ledger_secure_sdk_sys = { path = "../ledger_secure_sdk_sys", version = "1.4.4" }
+ledger_secure_sdk_sys = { path = "../ledger_secure_sdk_sys", version = "1.4.5" }
 
 [features]
 speculos = []

--- a/ledger_device_sdk/link_wrap.sh
+++ b/ledger_device_sdk/link_wrap.sh
@@ -7,8 +7,7 @@ set -x
 LD=${LD:-rust-lld}
 # Needed because LLD gets behavior from argv[0]
 LD=${LD/-ld/-lld}
-LIBC_PATH=$(arm-none-eabi-gcc -print-sysroot)/lib
-${LD} "$@" --emit-relocs -L ${LIBC_PATH} -lc
+${LD} "$@" --emit-relocs
 
 echo RUST_LLD DONE
 

--- a/ledger_device_sdk/link_wrap.sh
+++ b/ledger_device_sdk/link_wrap.sh
@@ -7,7 +7,8 @@ set -x
 LD=${LD:-rust-lld}
 # Needed because LLD gets behavior from argv[0]
 LD=${LD/-ld/-lld}
-${LD} "$@" --emit-relocs
+LIBC_PATH=$(arm-none-eabi-gcc -print-sysroot)/lib
+${LD} "$@" --emit-relocs -L ${LIBC_PATH} -lc
 
 echo RUST_LLD DONE
 

--- a/ledger_secure_sdk_sys/Cargo.toml
+++ b/ledger_secure_sdk_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_secure_sdk_sys"
-version = "1.4.4"
+version = "1.4.5"
 authors = ["yhql", "agrojean-ledger"]
 edition = "2021"
 license.workspace = true

--- a/ledger_secure_sdk_sys/build.rs
+++ b/ledger_secure_sdk_sys/build.rs
@@ -462,8 +462,8 @@ impl SDKBuilder {
 
         command.compile("ledger-secure-sdk");
 
+        /* Link with libc for unresolved symbols */
         let gcc_tc = self.gcc_toolchain.display().to_string();
-
         println!("cargo:rustc-link-lib=c");
         println!("cargo:rustc-link-search={gcc_tc}/lib");
     }

--- a/ledger_secure_sdk_sys/build.rs
+++ b/ledger_secure_sdk_sys/build.rs
@@ -536,6 +536,7 @@ impl SDKBuilder {
                     format!("-I{bsdk}/lib_nbgl/include/").as_str(),
                     format!("-I{bsdk}/lib_ux_sync/include/").as_str(),
                     format!("-I{bsdk}/lib_ux_nbgl/").as_str(),
+                    // format!("-I{bsdk}/qrcode/include/").as_str(),
                 ]);
                 bindings = bindings
                     .header(
@@ -553,6 +554,12 @@ impl SDKBuilder {
                     .header(
                         self.bolos_sdk
                             .join("lib_ux_nbgl/ux_nbgl.h")
+                            .to_str()
+                            .unwrap(),
+                    )
+                    .header(
+                        self.bolos_sdk
+                            .join("qrcode/include/qrcodegen.h")
                             .to_str()
                             .unwrap(),
                     )
@@ -724,6 +731,7 @@ fn configure_lib_nbgl(command: &mut cc::Build, bolos_sdk: &Path) {
         .file(bolos_sdk.join("lib_ux_sync/src/ux_sync.c"))
         .file(bolos_sdk.join("lib_bagl/src/bagl_fonts.c"))
         .file(bolos_sdk.join("src/os_printf.c"))
+        .file(bolos_sdk.join("qrcode/src/qrcodegen.c"))
         .files(
             glob(bolos_sdk.join("lib_nbgl/src/*.c").to_str().unwrap())
                 .unwrap()

--- a/ledger_secure_sdk_sys/sdk_flex.h
+++ b/ledger_secure_sdk_sys/sdk_flex.h
@@ -1,6 +1,7 @@
 #define ST33K1M5
 #define HAVE_DISPLAY_FAST_MODE
 #define HAVE_SPRINTF
+#define NBGL_QRCODE
 #define HAVE_SE_EINK_DISPLAY
 #define SCREEN_SIZE_WALLET
 #define HAVE_NBGL

--- a/ledger_secure_sdk_sys/sdk_stax.h
+++ b/ledger_secure_sdk_sys/sdk_stax.h
@@ -1,5 +1,6 @@
 #define ST33K1M5
 #define HAVE_SPRINTF
+#define NBGL_QRCODE
 #define HAVE_SE_EINK_DISPLAY
 #define SCREEN_SIZE_WALLET
 #define HAVE_NBGL


### PR DESCRIPTION
Compilation fails with a `rust-lld: error: undefined symbol: memchr` error.

### To reproduce 

* Spawn a `ledger-app-dev-tools` Docker container and open a terminal inside it.
* `git clone https://github.com/LedgerHQ/ledger-device-rust-sdk.git`
* `git checkout enable-qrcode`
* `rustup default nightly-2023-11-10-x86_64-unknown-linux-musl`
* `cd ledger_device_sdk/`
* `cargo run --target stax.json --package ledger_device_sdk --example nbgl_generic_review`