### PR TITLE
feat: add missing app os flags for appInfo instruction

### DIFF
--- a/ledger_device_sdk/src/io.rs
+++ b/ledger_device_sdk/src/io.rs
@@ -581,6 +581,13 @@ fn handle_bolos_apdu(com: &mut Comm, ins: u8) {
                 );
                 com.apdu_buffer[com.tx] = len as u8;
                 com.tx += (1 + len) as usize;
+
+                // to be fixed within io tasks
+                // return OS flags to notify of platform's global state (pin lock etc)
+                com.apdu_buffer[com.tx] = 1; // flags length
+                com.tx += 1;
+                com.apdu_buffer[com.tx] = os_flags() as u8;
+                com.tx += 1;
             }
             com.reply_ok();
         }


### PR DESCRIPTION
In the C SDK, the appInfo instruction has the appFlags available. On the Rust bindings, that is missing. That makes the same command for two different apps incompatible. I tested it locally, and it is possible to add it. I am not aware of reasons why it was missing. I suppose it was forgotten. 

Thanks! 