### PR TITLE
feat: use correct status word when device is locked

### DIFF
--- a/ledger_device_sdk/src/io.rs
+++ b/ledger_device_sdk/src/io.rs
@@ -23,6 +23,7 @@ pub enum StatusWords {
     UserCancelled = 0x6e04,
     Unknown = 0x6d00,
     Panic = 0xe000,
+    DeviceLocked = 0x5515,
 }
 
 #[derive(Debug)]

--- a/ledger_device_sdk/src/ui/gadgets.rs
+++ b/ledger_device_sdk/src/ui/gadgets.rs
@@ -603,7 +603,8 @@ impl<'a> MultiPageMenu<'a> {
                         // pin lock management
                         let (_res, ins) = UxEvent::block_and_get_event::<Temp>(self.comm);
                         if let Some(_e) = ins {
-                            self.comm.reply::<io::StatusWords>(io::StatusWords::Unknown);
+                            self.comm
+                                .reply::<io::StatusWords>(io::StatusWords::DeviceLocked);
                         }
                         // notify Ticker event only when redisplay is required
                         return EventOrPageIndex::Event(io::Event::Ticker);


### PR DESCRIPTION
When the app is active, and the device gets locked, the device returns "Instruction Not Supported". It does not seem correct, as the instruction is indeed supported. The device is actually locked instead. I changed the status word used on this scenario, in order to inform properly to the client. 