### PR TITLE
Display the s_arrow properly

### DIFF
--- a/ledger_device_sdk/src/ui/gadgets.rs
+++ b/ledger_device_sdk/src/ui/gadgets.rs
@@ -794,7 +794,9 @@ impl<'a> Field<'a> {
         loop {
             match get_event(&mut buttons) {
                 Some(ButtonEvent::LeftButtonPress) => {
-                    LEFT_S_ARROW.instant_display();
+                    if (!is_first_field) {
+                        LEFT_S_ARROW.instant_display();
+                    }
                 }
                 Some(ButtonEvent::RightButtonPress) => {
                     RIGHT_S_ARROW.instant_display();
@@ -933,7 +935,11 @@ impl<'a> MultiFieldReview<'a> {
                     crate::ui::screen_util::screen_update();
                     loop {
                         match get_event(&mut buttons) {
+                            Some(ButtonEvent::LeftButtonPress) => {
+                                LEFT_S_ARROW.instant_display();
+                            }
                             Some(ButtonEvent::LeftButtonRelease) => {
+                                LEFT_S_ARROW.erase();
                                 cur_page = cur_page.saturating_sub(1);
                                 break;
                             }
@@ -951,7 +957,14 @@ impl<'a> MultiFieldReview<'a> {
                     crate::ui::screen_util::screen_update();
                     loop {
                         match get_event(&mut buttons) {
+                            Some(ButtonEvent::LeftButtonPress) => {
+                                LEFT_S_ARROW.instant_display();
+                            }
+                            Some(ButtonEvent::RightButtonPress) => {
+                                RIGHT_S_ARROW.instant_display();
+                            }
                             Some(ButtonEvent::LeftButtonRelease) => {
+                                LEFT_S_ARROW.erase();
                                 cur_page = cur_page.saturating_sub(1);
                                 if cur_page == 0 && self.fields.is_empty() {
                                     display_first_page(&first_page_opt);
@@ -961,6 +974,7 @@ impl<'a> MultiFieldReview<'a> {
                                 break;
                             }
                             Some(ButtonEvent::RightButtonRelease) => {
+                                RIGHT_S_ARROW.erase();
                                 cur_page += 1;
                                 break;
                             }
@@ -1002,8 +1016,15 @@ fn display_first_page(page_opt: &Option<Page>) {
 
             let mut buttons = ButtonsState::new();
             loop {
-                if let Some(ButtonEvent::RightButtonRelease) = get_event(&mut buttons) {
-                    return;
+                match get_event(&mut buttons) {
+                    Some(ButtonEvent::RightButtonPress) => {
+                        RIGHT_S_ARROW.instant_display();
+                    }
+                    Some(ButtonEvent::RightButtonRelease) => {
+                        RIGHT_S_ARROW.erase();
+                        return;
+                    }
+                    _ => (),
                 }
             }
         }


### PR DESCRIPTION
This PR improves the display of the `s_arrow` when switching between the field pages and the confirm/cancel page in `MultiFieldReview`.