### PR TITLE
Allow custom definitions and flags for the C build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "ledger_device_sdk"
-version = "1.24.1"
+version = "1.24.2"
 dependencies = [
  "const-zero",
  "include_gif",
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "ledger_secure_sdk_sys"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_device_sdk"
-version = "1.24.1"
+version = "1.24.2"
 authors = ["yhql", "yogh333", "agrojean-ledger", "kingofpayne"]
 edition = "2021"
 license.workspace = true
@@ -21,7 +21,7 @@ rand_core = { version = "0.6.3", default-features = false }
 zeroize = { version = "1.6.0", default-features = false }
 numtoa = "0.2.4"
 const-zero = "0.1.1"
-ledger_secure_sdk_sys = { path = "../ledger_secure_sdk_sys", version = "1.10.0" }
+ledger_secure_sdk_sys = { path = "../ledger_secure_sdk_sys", version = "1.11.0" }
 
 [features]
 debug = []

--- a/ledger_secure_sdk_sys/Cargo.toml
+++ b/ledger_secure_sdk_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger_secure_sdk_sys"
-version = "1.10.0"
+version = "1.11.0"
 authors = ["yhql", "agrojean-ledger", "yogh333"]
 edition = "2021"
 license.workspace = true

--- a/ledger_secure_sdk_sys/build.rs
+++ b/ledger_secure_sdk_sys/build.rs
@@ -528,6 +528,30 @@ impl SDKBuilder<'_> {
             command.define(define, None);
         }
 
+        // Add defines and flags specified in the LEDGER_SDK_EXTRA_DEFINES and LEDGER_SDK_EXTRA_CFLAGS environment
+        // variables, if they are set.
+        // This allows apps to customize the build process. Since they are added after the default includes, they can
+        // override previous definitions.
+
+        println!("cargo:rerun-if-env-changed=LEDGER_SDK_EXTRA_DEFINES");
+        println!("cargo:rerun-if-env-changed=LEDGER_SDK_EXTRA_CFLAGS");
+
+        if let Ok(defs) = env::var("LEDGER_SDK_EXTRA_DEFINES") {
+            for d in defs.split_whitespace() {
+                if let Some((k, v)) = d.split_once('=') {
+                    command.define(k, Some(v));
+                } else {
+                    command.define(d, None);
+                }
+            }
+        }
+        if let Ok(flags) = env::var("LEDGER_SDK_EXTRA_CFLAGS") {
+            for f in flags.split_whitespace() {
+                command.flag(f);
+            }
+        }
+
+        /* Compile the SDK */
         command.compile("ledger-secure-sdk");
 
         /* Link with libc, libm and libgcc */


### PR DESCRIPTION
This introduces two environment variables: `LEDGER_SDK_EXTRA_DEFINES` and `LEDGER_SDK_EXTRA_CFLAGS`. These allow to add custom definitions and compiler flags during the build process of the C SDK, similarly to what C apps can achieve by customizing the `Makefile`.