### PR TITLE
Weak syscalls fix

### DIFF
--- a/ledger_secure_sdk_sys/build.rs
+++ b/ledger_secure_sdk_sys/build.rs
@@ -544,6 +544,9 @@ impl SDKBuilder<'_> {
                     .include(&glyphs_path)
                     .file(glyphs_path.join("glyphs.c"));
             }
+            if s.0 == "HAVE_IO_U2F" {
+                configure_lib_u2f(command, &self.device.c_sdk, only_includes);
+            }
         }
     }
 
@@ -827,6 +830,13 @@ fn configure_lib_nbgl(command: &mut cc::Build, c_sdk: &Path, only_includes: bool
         .include(c_sdk.join("qrcode/include/"))
         .include(c_sdk.join("lib_bagl/include/"))
         .include(&glyphs_path);
+}
+
+fn configure_lib_u2f(command: &mut cc::Build, c_sdk: &Path, only_includes: bool) {
+    if !only_includes {
+        command.file(c_sdk.join("lib_u2f/src/u2f_transport.c"));
+    }
+    command.include(c_sdk.join("lib_u2f/include"));
 }
 
 fn retrieve_csdk_info(device: &Device, path: &PathBuf) -> Result<CSDKInfo, SDKBuildError> {


### PR DESCRIPTION
Many syscalls are defined in `syscalls.c` as _weak_, because a second implementation in the SDK can replace them. This is needed for many features, as the code compiled by the feature provides a different implementation under the control of the app.

This PR separates the compilation of `syscalls.c` in a separate object file that is compiled last, which allows the linker to choose the strong definition if it exists. Some refactoring was needed because _includes_ need to be present in both cases, unlike C files that must not be duplicated.

After doing so, I was having linker errors related to the functions in `u2f_transport.c`, which indeed was not compiled. So I added the configuration for that in the second commit.