### PR TITLE
Use big-endian for long APDUs data length in header

### DIFF
--- a/ledger_device_sdk/src/io.rs
+++ b/ledger_device_sdk/src/io.rs
@@ -618,7 +618,7 @@ impl Comm {
                 (0, 6) => Err(StatusWords::BadLen),
                 (0, _) => {
                     let len =
-                        u16::from_le_bytes([self.apdu_buffer[5], self.apdu_buffer[6]]) as usize;
+                        u16::from_be_bytes([self.apdu_buffer[5], self.apdu_buffer[6]]) as usize;
                     get_data_from_buffer(len, 7)
                 }
                 (len, _) => get_data_from_buffer(len, 5),


### PR DESCRIPTION
The standard expects a 7-bytes header with the length expressed as a 0 followed by a 2-byte length in big-endian. The Rust SDK is incorrectly using little-endian.

This is technically a breaking change - but no Rust app currently uses long APDUs.

One example of an app in C using long APDUs (with the correct big-endian length encoding) is `app-security-key`, which decodes the APDU [here](https://github.com/LedgerHQ/app-security-key/blob/a985b5a84eaf9791314ebf4775b9299b6865b521/src/u2f_processing.c#L152).