### PR TITLE
Compile 'io_legacy' at crate visibility when 'io_new' is present

### DIFF
--- a/ledger_device_sdk/src/lib.rs
+++ b/ledger_device_sdk/src/lib.rs
@@ -11,7 +11,6 @@ pub mod ecc;
 pub mod hash;
 pub mod hmac;
 pub(crate) mod io_callbacks;
-#[cfg(not(feature = "io_new"))]
 pub(crate) mod io_legacy;
 #[cfg(feature = "io_new")]
 pub(crate) mod io_new;


### PR DESCRIPTION
`io_new` imports members from `io_legacy`, but it was incorrectly gated away.