### PR TITLE
Migrate from 2021 to 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,18 +10,18 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bindgen"
@@ -40,20 +40,20 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder-lite"
@@ -63,9 +63,13 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cexpr"
@@ -78,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clang-sys"
@@ -107,9 +111,9 @@ checksum = "a3c6565524986fe3225da0beb9b4aa55ebc73cd57ff8cb4ccf016ca4c8d006af"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -122,9 +126,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedded-alloc"
@@ -138,18 +142,24 @@ dependencies = [
 
 [[package]]
 name = "fdeflate"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
 
 [[package]]
-name = "flate2"
-version = "1.1.5"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -167,15 +177,15 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -239,18 +249,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -261,15 +271,15 @@ checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minimal-lexical"
@@ -289,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -324,9 +334,9 @@ checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
 
 [[package]]
 name = "png"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -337,37 +347,34 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pxfm"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
-dependencies = [
- "num-traits",
-]
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -380,9 +387,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -392,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -403,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
@@ -439,7 +446,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -463,9 +470,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "syn"
@@ -480,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -499,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "weezl"
@@ -510,77 +517,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"
-version = "1.0.12"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/include_gif/Cargo.toml
+++ b/include_gif/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "include_gif"
 version = "1.2.6"
-edition = "2021"
+edition = "2024"
 license.workspace = true
 repository.workspace = true
 description = "procedural macro that packs a gif image into a byte representation"

--- a/include_gif/src/lib.rs
+++ b/include_gif/src/lib.rs
@@ -3,7 +3,7 @@ extern crate proc_macro;
 use image::*;
 use proc_macro::TokenStream;
 use std::io::Write;
-use syn::{parse_macro_input, Ident, LitStr};
+use syn::{Ident, LitStr, parse_macro_input};
 
 enum BppFormat {
     Bpp1 = 0,

--- a/ledger_device_sdk/Cargo.toml
+++ b/ledger_device_sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ledger_device_sdk"
 version = "1.34.0"
 authors = ["Ledger"]
-edition = "2021"
+edition = "2024"
 license.workspace = true
 repository.workspace = true
 description = "Ledger device Rust SDK"

--- a/ledger_device_sdk/build.rs
+++ b/ledger_device_sdk/build.rs
@@ -180,7 +180,9 @@ fn generate_install_parameters() {
     }
 
     // If we get here, we didn't find any ledger metadata - this is OK for non-app builds
-    println!("cargo:warning=No [package.metadata.ledger] section found - empty install parameters generation");
+    println!(
+        "cargo:warning=No [package.metadata.ledger] section found - empty install parameters generation"
+    );
     // Write empty install parameters
     let out_dir = std::env::var("OUT_DIR").unwrap();
     std::fs::write(

--- a/ledger_device_sdk/examples/nbgl_action.rs
+++ b/ledger_device_sdk/examples/nbgl_action.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use include_gif::include_gif;
-use ledger_device_sdk::nbgl::{init_comm, NbglAction, NbglGlyph};
+use ledger_device_sdk::nbgl::{NbglAction, NbglGlyph, init_comm};
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);

--- a/ledger_device_sdk/examples/nbgl_action.rs
+++ b/ledger_device_sdk/examples/nbgl_action.rs
@@ -7,7 +7,7 @@ use ledger_device_sdk::nbgl::{NbglAction, NbglGlyph, init_comm};
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_address_review.rs
+++ b/ledger_device_sdk/examples/nbgl_address_review.rs
@@ -3,7 +3,7 @@
 
 use include_gif::include_gif;
 use ledger_device_sdk::nbgl::{
-    init_comm, Field, NbglAddressReview, NbglGlyph, NbglReviewStatus, StatusType,
+    Field, NbglAddressReview, NbglGlyph, NbglReviewStatus, StatusType, init_comm,
 };
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);

--- a/ledger_device_sdk/examples/nbgl_address_review.rs
+++ b/ledger_device_sdk/examples/nbgl_address_review.rs
@@ -9,7 +9,7 @@ use ledger_device_sdk::nbgl::{
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_advance_review.rs
+++ b/ledger_device_sdk/examples/nbgl_advance_review.rs
@@ -3,7 +3,7 @@
 
 use include_gif::include_gif;
 use ledger_device_sdk::nbgl::{
-    init_comm, Field, NbglAdvanceReview, NbglGlyph, NbglReviewStatus, StatusType, TransactionType,
+    Field, NbglAdvanceReview, NbglGlyph, NbglReviewStatus, StatusType, TransactionType, init_comm,
 };
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);

--- a/ledger_device_sdk/examples/nbgl_advance_review.rs
+++ b/ledger_device_sdk/examples/nbgl_advance_review.rs
@@ -9,7 +9,7 @@ use ledger_device_sdk::nbgl::{
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_choice.rs
+++ b/ledger_device_sdk/examples/nbgl_choice.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use include_gif::include_gif;
-use ledger_device_sdk::nbgl::{init_comm, NbglChoice, NbglGlyph, NbglStatus};
+use ledger_device_sdk::nbgl::{NbglChoice, NbglGlyph, NbglStatus, init_comm};
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);

--- a/ledger_device_sdk/examples/nbgl_choice.rs
+++ b/ledger_device_sdk/examples/nbgl_choice.rs
@@ -7,7 +7,7 @@ use ledger_device_sdk::nbgl::{NbglChoice, NbglGlyph, NbglStatus, init_comm};
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_generic_review.rs
+++ b/ledger_device_sdk/examples/nbgl_generic_review.rs
@@ -13,7 +13,7 @@ use core::ops::Not;
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_generic_review.rs
+++ b/ledger_device_sdk/examples/nbgl_generic_review.rs
@@ -3,9 +3,9 @@
 
 use include_gif::include_gif;
 use ledger_device_sdk::nbgl::{
-    init_comm, CenteredInfo, CenteredInfoStyle, Field, InfoButton, InfoLongPress, InfosList,
-    NbglChoice, NbglGenericReview, NbglGlyph, NbglPageContent, NbglStatus, TagValueConfirm,
-    TagValueList, TuneIndex,
+    CenteredInfo, CenteredInfoStyle, Field, InfoButton, InfoLongPress, InfosList, NbglChoice,
+    NbglGenericReview, NbglGlyph, NbglPageContent, NbglStatus, TagValueConfirm, TagValueList,
+    TuneIndex, init_comm,
 };
 
 use core::ops::Not;

--- a/ledger_device_sdk/examples/nbgl_generic_settings.rs
+++ b/ledger_device_sdk/examples/nbgl_generic_settings.rs
@@ -13,7 +13,7 @@ mod settings {
 
     // This is necessary to store the object in NVM and not in RAM
     const SETTINGS_SIZE: usize = 10;
-    #[link_section = ".nvm_data"]
+    #[unsafe(link_section = ".nvm_data")]
     static mut DATA: NVMData<AtomicStorage<[u8; SETTINGS_SIZE]>> =
         NVMData::new(AtomicStorage::new(&[0u8; SETTINGS_SIZE]));
 
@@ -63,7 +63,7 @@ mod settings {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_generic_settings.rs
+++ b/ledger_device_sdk/examples/nbgl_generic_settings.rs
@@ -1,15 +1,15 @@
 #![no_std]
 #![no_main]
 
-use ledger_device_sdk::nbgl::{init_comm, NbglGenericSettings};
+use ledger_device_sdk::nbgl::{NbglGenericSettings, init_comm};
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
 mod settings {
 
-    use ledger_device_sdk::nvm::*;
     use ledger_device_sdk::NVMData;
+    use ledger_device_sdk::nvm::*;
 
     // This is necessary to store the object in NVM and not in RAM
     const SETTINGS_SIZE: usize = 10;

--- a/ledger_device_sdk/examples/nbgl_home_and_settings.rs
+++ b/ledger_device_sdk/examples/nbgl_home_and_settings.rs
@@ -34,7 +34,7 @@ mod settings {
 
     // This is necessary to store the object in NVM and not in RAM
     const SETTINGS_SIZE: usize = 10;
-    #[link_section = ".nvm_data"]
+    #[unsafe(link_section = ".nvm_data")]
     static mut DATA: NVMData<AtomicStorage<[u8; SETTINGS_SIZE]>> =
         NVMData::new(AtomicStorage::new(&[0u8; SETTINGS_SIZE]));
 
@@ -84,7 +84,7 @@ mod settings {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_home_and_settings.rs
+++ b/ledger_device_sdk/examples/nbgl_home_and_settings.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use include_gif::include_gif;
-use ledger_device_sdk::nbgl::{init_comm, NbglGlyph, NbglHomeAndSettings};
+use ledger_device_sdk::nbgl::{NbglGlyph, NbglHomeAndSettings, init_comm};
 // use ledger_device_sdk::nvm::*;
 // use ledger_device_sdk::NVMData;
 use ledger_device_sdk::io::{ApduHeader, StatusWords};
@@ -29,8 +29,8 @@ impl TryFrom<ApduHeader> for Instruction {
 
 mod settings {
 
-    use ledger_device_sdk::nvm::*;
     use ledger_device_sdk::NVMData;
+    use ledger_device_sdk::nvm::*;
 
     // This is necessary to store the object in NVM and not in RAM
     const SETTINGS_SIZE: usize = 10;

--- a/ledger_device_sdk/examples/nbgl_keypad.rs
+++ b/ledger_device_sdk/examples/nbgl_keypad.rs
@@ -6,7 +6,7 @@ use ledger_device_sdk::nbgl::{NbglKeypad, NbglStatus, init_comm};
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_keypad.rs
+++ b/ledger_device_sdk/examples/nbgl_keypad.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use ledger_device_sdk::nbgl::{init_comm, NbglKeypad, NbglStatus};
+use ledger_device_sdk::nbgl::{NbglKeypad, NbglStatus, init_comm};
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);

--- a/ledger_device_sdk/examples/nbgl_review.rs
+++ b/ledger_device_sdk/examples/nbgl_review.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use include_gif::include_gif;
-use ledger_device_sdk::nbgl::{init_comm, Field, NbglGlyph, NbglReview, NbglReviewStatus};
+use ledger_device_sdk::nbgl::{Field, NbglGlyph, NbglReview, NbglReviewStatus, init_comm};
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);

--- a/ledger_device_sdk/examples/nbgl_review.rs
+++ b/ledger_device_sdk/examples/nbgl_review.rs
@@ -7,7 +7,7 @@ use ledger_device_sdk::nbgl::{Field, NbglGlyph, NbglReview, NbglReviewStatus, in
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_review_extended.rs
+++ b/ledger_device_sdk/examples/nbgl_review_extended.rs
@@ -7,7 +7,7 @@ use ledger_device_sdk::nbgl::{Field, NbglGlyph, NbglReviewExtended, NbglReviewSt
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_review_extended.rs
+++ b/ledger_device_sdk/examples/nbgl_review_extended.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use include_gif::include_gif;
-use ledger_device_sdk::nbgl::{init_comm, Field, NbglGlyph, NbglReviewExtended, NbglReviewStatus};
+use ledger_device_sdk::nbgl::{Field, NbglGlyph, NbglReviewExtended, NbglReviewStatus, init_comm};
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);

--- a/ledger_device_sdk/examples/nbgl_spinner.rs
+++ b/ledger_device_sdk/examples/nbgl_spinner.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use ledger_device_sdk::nbgl::{init_comm, NbglReviewStatus, NbglSpinner};
+use ledger_device_sdk::nbgl::{NbglReviewStatus, NbglSpinner, init_comm};
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);

--- a/ledger_device_sdk/examples/nbgl_spinner.rs
+++ b/ledger_device_sdk/examples/nbgl_spinner.rs
@@ -6,7 +6,7 @@ use ledger_device_sdk::nbgl::{NbglReviewStatus, NbglSpinner, init_comm};
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/nbgl_streaming_review.rs
+++ b/ledger_device_sdk/examples/nbgl_streaming_review.rs
@@ -3,8 +3,8 @@
 
 use include_gif::include_gif;
 use ledger_device_sdk::nbgl::{
-    init_comm, Field, NbglGlyph, NbglReviewStatus, NbglStreamingReview, NbglStreamingReviewStatus,
-    TransactionType,
+    Field, NbglGlyph, NbglReviewStatus, NbglStreamingReview, NbglStreamingReviewStatus,
+    TransactionType, init_comm,
 };
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);

--- a/ledger_device_sdk/examples/nbgl_streaming_review.rs
+++ b/ledger_device_sdk/examples/nbgl_streaming_review.rs
@@ -10,7 +10,7 @@ use ledger_device_sdk::nbgl::{
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/pki.rs
+++ b/ledger_device_sdk/examples/pki.rs
@@ -29,7 +29,7 @@ impl TryFrom<ApduHeader> for Instruction {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/pki.rs
+++ b/ledger_device_sdk/examples/pki.rs
@@ -5,7 +5,7 @@ use include_gif::include_gif;
 use ledger_device_sdk::ecc::CurvesId;
 use ledger_device_sdk::hash::HashInit;
 use ledger_device_sdk::io::{ApduHeader, StatusWords};
-use ledger_device_sdk::nbgl::{init_comm, NbglGlyph, NbglHomeAndSettings};
+use ledger_device_sdk::nbgl::{NbglGlyph, NbglHomeAndSettings, init_comm};
 use ledger_device_sdk::pki::pki_check_signature;
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);

--- a/ledger_device_sdk/examples/tlv_dynamic_token.rs
+++ b/ledger_device_sdk/examples/tlv_dynamic_token.rs
@@ -27,7 +27,7 @@ impl TryFrom<ApduHeader> for Instruction {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/tlv_dynamic_token.rs
+++ b/ledger_device_sdk/examples/tlv_dynamic_token.rs
@@ -3,8 +3,8 @@
 
 use include_gif::include_gif;
 use ledger_device_sdk::io::{ApduHeader, StatusWords};
-use ledger_device_sdk::nbgl::{init_comm, NbglGlyph, NbglHomeAndSettings};
-use ledger_device_sdk::tlv::{parse_dynamic_token_tlv, DynamicTokenOut};
+use ledger_device_sdk::nbgl::{NbglGlyph, NbglHomeAndSettings, init_comm};
+use ledger_device_sdk::tlv::{DynamicTokenOut, parse_dynamic_token_tlv};
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);

--- a/ledger_device_sdk/examples/tlv_generic.rs
+++ b/ledger_device_sdk/examples/tlv_generic.rs
@@ -59,7 +59,7 @@ static HANDLERS: &[Handler<Out>] = &[
     }, // accept & ignore
 ];
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let payload: &[u8] = &[0x01, 0x03, b'a', b'b', b'c', 0x02, 0x01, b'x'];
 

--- a/ledger_device_sdk/examples/tlv_generic.rs
+++ b/ledger_device_sdk/examples/tlv_generic.rs
@@ -3,7 +3,7 @@
 
 use ledger_device_sdk::tag_to_flag_u64;
 use ledger_device_sdk::tlv::tlv_generic::{
-    parse, Handler, ParseCfg, Received, Result, Tag, TlvData,
+    Handler, ParseCfg, Received, Result, Tag, TlvData, parse,
 };
 
 extern crate alloc;

--- a/ledger_device_sdk/examples/tlv_trusted_name.rs
+++ b/ledger_device_sdk/examples/tlv_trusted_name.rs
@@ -27,7 +27,7 @@ impl TryFrom<ApduHeader> for Instruction {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn sample_main() {
     let comm = init_comm(&COMM);
 

--- a/ledger_device_sdk/examples/tlv_trusted_name.rs
+++ b/ledger_device_sdk/examples/tlv_trusted_name.rs
@@ -3,8 +3,8 @@
 
 use include_gif::include_gif;
 use ledger_device_sdk::io::{ApduHeader, StatusWords};
-use ledger_device_sdk::nbgl::{init_comm, NbglGlyph, NbglHomeAndSettings};
-use ledger_device_sdk::tlv::{parse_trusted_name_tlv, TrustedNameOut};
+use ledger_device_sdk::nbgl::{NbglGlyph, NbglHomeAndSettings, init_comm};
+use ledger_device_sdk::tlv::{TrustedNameOut, parse_trusted_name_tlv};
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 ledger_device_sdk::define_comm!(COMM);

--- a/ledger_device_sdk/src/app_info.rs
+++ b/ledger_device_sdk/src/app_info.rs
@@ -17,8 +17,8 @@ const_cstr!(
 );
 
 #[used]
-#[no_mangle]
-#[link_section = ".install_parameters"]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = ".install_parameters")]
 #[allow(non_upper_case_globals)]
 static install_parameters: [u8; include!(concat!(env!("OUT_DIR"), "/install_params_len.txt"))] =
     include!(concat!(env!("OUT_DIR"), "/install_params.txt"));

--- a/ledger_device_sdk/src/ecc.rs
+++ b/ledger_device_sdk/src/ecc.rs
@@ -302,7 +302,7 @@ impl Default for Ed25519Stream {
 }
 
 macro_rules! check_cx_ok {
-    ($fn_call:expr) => {{
+    ($fn_call:expr_2021) => {{
         let err = unsafe { $fn_call };
         if err != CX_OK {
             return Err(err.into());
@@ -778,7 +778,7 @@ impl SeedDerive for Stark256 {
 /// Each curve has a method `new()` that takes no arguments and returns the correctly
 /// const-typed `ECPrivateKey`.
 macro_rules! impl_curve {
-    ($typename:ident, $size:expr, $curvetype:expr) => {
+    ($typename:ident, $size:expr_2021, $curvetype:expr_2021) => {
         pub struct $typename {}
         impl $typename {
             #[allow(clippy::new_ret_no_self)]

--- a/ledger_device_sdk/src/ecc.rs
+++ b/ledger_device_sdk/src/ecc.rs
@@ -302,7 +302,7 @@ impl Default for Ed25519Stream {
 }
 
 macro_rules! check_cx_ok {
-    ($fn_call:expr_2021) => {{
+    ($fn_call:expr) => {{
         let err = unsafe { $fn_call };
         if err != CX_OK {
             return Err(err.into());
@@ -778,7 +778,7 @@ impl SeedDerive for Stark256 {
 /// Each curve has a method `new()` that takes no arguments and returns the correctly
 /// const-typed `ECPrivateKey`.
 macro_rules! impl_curve {
-    ($typename:ident, $size:expr_2021, $curvetype:expr_2021) => {
+    ($typename:ident, $size:expr, $curvetype:expr) => {
         pub struct $typename {}
         impl $typename {
             #[allow(clippy::new_ret_no_self)]

--- a/ledger_device_sdk/src/ecc.rs
+++ b/ledger_device_sdk/src/ecc.rs
@@ -1,7 +1,7 @@
 use ledger_secure_sdk_sys::*;
 use zeroize::Zeroize;
 
-use crate::hash::{sha2::Sha2_512, HashInit};
+use crate::hash::{HashInit, sha2::Sha2_512};
 
 mod stark;
 

--- a/ledger_device_sdk/src/hash.rs
+++ b/ledger_device_sdk/src/hash.rs
@@ -84,7 +84,7 @@ pub trait HashInit: Sized {
 }
 
 macro_rules! impl_hash {
-    ($typename:ident, $ctxname:ident, $initfname:ident, $size:expr) => {
+    ($typename:ident, $ctxname:ident, $initfname:ident, $size:expr_2021) => {
         #[derive(Default)]
         #[allow(non_camel_case_types)]
         pub struct $typename {

--- a/ledger_device_sdk/src/hash.rs
+++ b/ledger_device_sdk/src/hash.rs
@@ -84,7 +84,7 @@ pub trait HashInit: Sized {
 }
 
 macro_rules! impl_hash {
-    ($typename:ident, $ctxname:ident, $initfname:ident, $size:expr_2021) => {
+    ($typename:ident, $ctxname:ident, $initfname:ident, $size:expr) => {
         #[derive(Default)]
         #[allow(non_camel_case_types)]
         pub struct $typename {

--- a/ledger_device_sdk/src/hash.rs
+++ b/ledger_device_sdk/src/hash.rs
@@ -1,6 +1,6 @@
 use ledger_secure_sdk_sys::{
-    cx_hash_final, cx_hash_get_size, cx_hash_no_throw, cx_hash_t, cx_hash_update,
-    CX_INVALID_PARAMETER, CX_LAST, CX_OK,
+    CX_INVALID_PARAMETER, CX_LAST, CX_OK, cx_hash_final, cx_hash_get_size, cx_hash_no_throw,
+    cx_hash_t, cx_hash_update,
 };
 
 pub mod blake2;
@@ -143,9 +143,9 @@ pub(crate) use impl_hash;
 #[cfg(test)]
 mod tests {
     use crate::assert_eq_err as assert_eq;
+    use crate::hash::HashInit;
     use crate::hash::sha2::Sha2_256;
     use crate::hash::sha3::*;
-    use crate::hash::HashInit;
     use crate::testing::TestType;
     use testmacro::test_item as test;
 

--- a/ledger_device_sdk/src/hmac.rs
+++ b/ledger_device_sdk/src/hmac.rs
@@ -1,7 +1,7 @@
 //! Hash-based message authentication code (HMAC) related functions
 use ledger_secure_sdk_sys::{
-    cx_hmac_final, cx_hmac_no_throw, cx_hmac_t, cx_hmac_update, CX_INVALID_PARAMETER, CX_LAST,
-    CX_OK,
+    CX_INVALID_PARAMETER, CX_LAST, CX_OK, cx_hmac_final, cx_hmac_no_throw, cx_hmac_t,
+    cx_hmac_update,
 };
 
 pub mod ripemd;
@@ -129,8 +129,8 @@ pub(crate) use impl_hmac;
 #[cfg(test)]
 mod tests {
     use crate::assert_eq_err as assert_eq;
-    use crate::hmac::ripemd::Ripemd160;
     use crate::hmac::HMACInit;
+    use crate::hmac::ripemd::Ripemd160;
     use crate::testing::TestType;
     use testmacro::test_item as test;
 

--- a/ledger_device_sdk/src/io_legacy.rs
+++ b/ledger_device_sdk/src/io_legacy.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(feature = "io_new", allow(dead_code))]
 
 #[cfg(any(target_os = "nanosplus", target_os = "nanox"))]
-use ledger_secure_sdk_sys::buttons::{get_button_event, ButtonEvent, ButtonsState};
+use ledger_secure_sdk_sys::buttons::{ButtonEvent, ButtonsState, get_button_event};
 use ledger_secure_sdk_sys::seph as sys_seph;
 use ledger_secure_sdk_sys::*;
 

--- a/ledger_device_sdk/src/io_new.rs
+++ b/ledger_device_sdk/src/io_new.rs
@@ -128,7 +128,7 @@ macro_rules! define_comm {
 #[cfg(any(target_os = "nanosplus", target_os = "nanox"))]
 use crate::buttons::ButtonEvent;
 #[cfg(any(target_os = "nanosplus", target_os = "nanox"))]
-use ledger_secure_sdk_sys::buttons::{get_button_event, ButtonsState};
+use ledger_secure_sdk_sys::buttons::{ButtonsState, get_button_event};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommError {

--- a/ledger_device_sdk/src/io_new/bolos.rs
+++ b/ledger_device_sdk/src/io_new/bolos.rs
@@ -2,8 +2,8 @@ use super::{Comm, StatusWords};
 use ledger_secure_sdk_sys::*;
 
 use crate::io_legacy::{
-    PkiLoadCertificateError, SyscallError, BOLOS_INS_GET_VERSION, BOLOS_INS_QUIT,
-    BOLOS_INS_SET_PKI_CERT,
+    BOLOS_INS_GET_VERSION, BOLOS_INS_QUIT, BOLOS_INS_SET_PKI_CERT, PkiLoadCertificateError,
+    SyscallError,
 };
 
 /// Handle internal BOLOS APDUs (CLA = 0xB0, P1 = 0x00, P2 = 0x00).

--- a/ledger_device_sdk/src/io_new/callbacks.rs
+++ b/ledger_device_sdk/src/io_new/callbacks.rs
@@ -32,7 +32,7 @@ pub(super) fn is_comm_null() -> bool {
 
 // Converts the pointer back to the concrete Comm<N> type.
 unsafe fn get_comm<const N: usize>() -> &'static mut Comm<N> {
-    &mut *(CURRENT_COMM as *mut Comm<N>)
+    unsafe { &mut *(CURRENT_COMM as *mut Comm<N>) }
 }
 
 /// Register a type-erased panic handler for the current Comm instance.

--- a/ledger_device_sdk/src/io_new/event.rs
+++ b/ledger_device_sdk/src/io_new/event.rs
@@ -4,7 +4,7 @@ use crate::seph;
 #[cfg(any(target_os = "nanosplus", target_os = "nanox"))]
 use crate::buttons::ButtonEvent;
 #[cfg(any(target_os = "nanosplus", target_os = "nanox"))]
-use ledger_secure_sdk_sys::buttons::{get_button_event, ButtonsState};
+use ledger_secure_sdk_sys::buttons::{ButtonsState, get_button_event};
 
 #[cfg(any(
     target_os = "nanox",

--- a/ledger_device_sdk/src/lib.rs
+++ b/ledger_device_sdk/src/lib.rs
@@ -91,7 +91,7 @@ use ledger_secure_sdk_sys::{pic_rs, pic_rs_mut};
 /// as the project's current panic handler
 #[macro_export]
 macro_rules! set_panic {
-    ($f:expr) => {
+    ($f:expr_2021) => {
         use core::panic::PanicInfo;
         #[panic_handler]
         fn panic(info: &PanicInfo) -> ! {
@@ -100,12 +100,12 @@ macro_rules! set_panic {
     };
 }
 
-extern "C" {
+unsafe extern "C" {
     fn c_main();
 }
 
-#[link_section = ".boot"]
-#[no_mangle]
+#[unsafe(link_section = ".boot")]
+#[unsafe(no_mangle)]
 pub extern "C" fn _start() -> ! {
     // Main is in C until the try_context can be set properly from Rust
     unsafe { c_main() };
@@ -146,7 +146,7 @@ impl<T> Pic<T> {
 }
 
 // Needed for `NVMData<T>` to function properly
-extern "C" {
+unsafe extern "C" {
     // This is a linker script symbol defining the beginning of
     // the .nvm_data section. Declaring it as a static u32
     // (as is usually done) will result in a r9-indirect memory
@@ -202,7 +202,7 @@ impl<T> NVMData<T> {
 }
 
 #[cfg(test)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 fn sample_main() {
     test_main();
 }

--- a/ledger_device_sdk/src/lib.rs
+++ b/ledger_device_sdk/src/lib.rs
@@ -91,7 +91,7 @@ use ledger_secure_sdk_sys::{pic_rs, pic_rs_mut};
 /// as the project's current panic handler
 #[macro_export]
 macro_rules! set_panic {
-    ($f:expr_2021) => {
+    ($f:expr) => {
         use core::panic::PanicInfo;
         #[panic_handler]
         fn panic(info: &PanicInfo) -> ! {

--- a/ledger_device_sdk/src/libcall.rs
+++ b/ledger_device_sdk/src/libcall.rs
@@ -1,4 +1,4 @@
-use ledger_secure_sdk_sys::{libargs_t, CHECK_ADDRESS, GET_PRINTABLE_AMOUNT, SIGN_TRANSACTION};
+use ledger_secure_sdk_sys::{CHECK_ADDRESS, GET_PRINTABLE_AMOUNT, SIGN_TRANSACTION, libargs_t};
 
 pub mod string;
 pub mod swap;

--- a/ledger_device_sdk/src/libcall/swap.rs
+++ b/ledger_device_sdk/src/libcall/swap.rs
@@ -33,8 +33,8 @@
 ))]
 use crate::nbgl::NbglSpinner;
 use ledger_secure_sdk_sys::{
-    check_address_parameters_t, create_transaction_parameters_t, get_printable_amount_parameters_t,
-    libargs_s__bindgen_ty_1, libargs_t, MAX_PRINTABLE_AMOUNT_SIZE,
+    MAX_PRINTABLE_AMOUNT_SIZE, check_address_parameters_t, create_transaction_parameters_t,
+    get_printable_amount_parameters_t, libargs_s__bindgen_ty_1, libargs_t,
 };
 
 #[cfg(feature = "io_new")]
@@ -304,10 +304,10 @@ pub struct CheckAddressParams<
 //  --8<-- [end:CheckAddressParams]
 
 impl<
-        const COIN_CONFIG_BUF_SIZE: usize,
-        const ADDRESS_BUF_SIZE: usize,
-        const ADDRESS_EXTRA_ID_BUF_SIZE: usize,
-    > Default
+    const COIN_CONFIG_BUF_SIZE: usize,
+    const ADDRESS_BUF_SIZE: usize,
+    const ADDRESS_EXTRA_ID_BUF_SIZE: usize,
+> Default
     for CheckAddressParams<COIN_CONFIG_BUF_SIZE, ADDRESS_BUF_SIZE, ADDRESS_EXTRA_ID_BUF_SIZE>
 {
     fn default() -> Self {
@@ -349,10 +349,10 @@ pub struct PrintableAmountParams<
 //  --8<-- [end:PrintableAmountParams]
 
 impl<
-        const COIN_CONFIG_BUF_SIZE: usize,
-        const ADDRESS_BUF_SIZE: usize,
-        const ADDRESS_EXTRA_ID_BUF_SIZE: usize,
-    > Default
+    const COIN_CONFIG_BUF_SIZE: usize,
+    const ADDRESS_BUF_SIZE: usize,
+    const ADDRESS_EXTRA_ID_BUF_SIZE: usize,
+> Default
     for PrintableAmountParams<COIN_CONFIG_BUF_SIZE, ADDRESS_BUF_SIZE, ADDRESS_EXTRA_ID_BUF_SIZE>
 {
     fn default() -> Self {
@@ -403,11 +403,10 @@ pub struct CreateTxParams<
 //  --8<-- [end:CreateTxParams]
 
 impl<
-        const COIN_CONFIG_BUF_SIZE: usize,
-        const ADDRESS_BUF_SIZE: usize,
-        const ADDRESS_EXTRA_ID_BUF_SIZE: usize,
-    > Default
-    for CreateTxParams<COIN_CONFIG_BUF_SIZE, ADDRESS_BUF_SIZE, ADDRESS_EXTRA_ID_BUF_SIZE>
+    const COIN_CONFIG_BUF_SIZE: usize,
+    const ADDRESS_BUF_SIZE: usize,
+    const ADDRESS_EXTRA_ID_BUF_SIZE: usize,
+> Default for CreateTxParams<COIN_CONFIG_BUF_SIZE, ADDRESS_BUF_SIZE, ADDRESS_EXTRA_ID_BUF_SIZE>
 {
     fn default() -> Self {
         CreateTxParams {

--- a/ledger_device_sdk/src/libcall/swap.rs
+++ b/ledger_device_sdk/src/libcall/swap.rs
@@ -573,7 +573,7 @@ pub fn get_printable_amount_params<
     printable_amount_params
 }
 
-extern "C" {
+unsafe extern "C" {
     fn c_reset_bss();
     fn c_boot_std();
 }

--- a/ledger_device_sdk/src/log.rs
+++ b/ledger_device_sdk/src/log.rs
@@ -134,7 +134,7 @@ impl Write for DBG {
 #[cfg(feature = "debug")]
 #[macro_export]
 macro_rules! log {
-    ($lvl:expr, $fmt:literal $($arg:tt)*) => ({
+    ($lvl:expr_2021, $fmt:literal $($arg:tt)*) => ({
         use core::fmt::Write;
         let _ = core::write!($crate::log::DBG, concat!("[{}] {}:{}: ", $fmt, "\r\n"), $lvl, core::file!(), core::line!() $($arg)*);
     });

--- a/ledger_device_sdk/src/log.rs
+++ b/ledger_device_sdk/src/log.rs
@@ -134,7 +134,7 @@ impl Write for DBG {
 #[cfg(feature = "debug")]
 #[macro_export]
 macro_rules! log {
-    ($lvl:expr_2021, $fmt:literal $($arg:tt)*) => ({
+    ($lvl:expr, $fmt:literal $($arg:tt)*) => ({
         use core::fmt::Write;
         let _ = core::write!($crate::log::DBG, concat!("[{}] {}:{}: ", $fmt, "\r\n"), $lvl, core::file!(), core::line!() $($arg)*);
     });

--- a/ledger_device_sdk/src/math.rs
+++ b/ledger_device_sdk/src/math.rs
@@ -2,10 +2,11 @@ use core::default::Default;
 use core::fmt::Display;
 use core::ops::{Add, AddAssign, Mul, Rem, RemAssign, Sub, SubAssign};
 use ledger_secure_sdk_sys::{
-    cx_math_add_no_throw, cx_math_addm_no_throw, cx_math_cmp_no_throw, cx_math_invintm_no_throw,
-    cx_math_invprimem_no_throw, cx_math_is_prime_no_throw, cx_math_modm_no_throw,
-    cx_math_mult_no_throw, cx_math_multm_no_throw, cx_math_next_prime_no_throw,
-    cx_math_powm_no_throw, cx_math_sub_no_throw, cx_math_subm_no_throw, CX_OK,
+    CX_OK, cx_math_add_no_throw, cx_math_addm_no_throw, cx_math_cmp_no_throw,
+    cx_math_invintm_no_throw, cx_math_invprimem_no_throw, cx_math_is_prime_no_throw,
+    cx_math_modm_no_throw, cx_math_mult_no_throw, cx_math_multm_no_throw,
+    cx_math_next_prime_no_throw, cx_math_powm_no_throw, cx_math_sub_no_throw,
+    cx_math_subm_no_throw,
 };
 
 #[derive(Debug, Copy, Clone)]

--- a/ledger_device_sdk/src/nbgl.rs
+++ b/ledger_device_sdk/src/nbgl.rs
@@ -166,7 +166,7 @@ trait SyncNBGL: Sized {
     }
 }
 
-unsafe extern "C" fn choice_callback(confirm: bool) {
+unsafe extern "C" fn choice_callback(confirm: bool) { unsafe {
     if G_CONFIRM_ASK_WHEN_TRUE || G_CONFIRM_ASK_WHEN_FALSE {
         let mut idx = 0usize;
         if G_CONFIRM_ASK_WHEN_TRUE && confirm {
@@ -192,31 +192,31 @@ unsafe extern "C" fn choice_callback(confirm: bool) {
         };
         G_ENDED = true;
     }
-}
+}}
 
-unsafe extern "C" fn confirm_choice_callback() {
+unsafe extern "C" fn confirm_choice_callback() { unsafe {
     G_ENDED = true;
-}
+}}
 
-unsafe extern "C" fn skip_callback() {
+unsafe extern "C" fn skip_callback() { unsafe {
     G_RET = SyncNbgl::UxSyncRetSkipped.into();
     G_ENDED = true;
-}
+}}
 
-unsafe extern "C" fn quit_callback() {
+unsafe extern "C" fn quit_callback() { unsafe {
     G_RET = SyncNbgl::UxSyncRetQuitted.into();
     G_ENDED = true;
-}
+}}
 
-unsafe extern "C" fn continue_callback() {
+unsafe extern "C" fn continue_callback() { unsafe {
     G_RET = SyncNbgl::UxSyncRetContinue.into();
     G_ENDED = true;
-}
+}}
 
-unsafe extern "C" fn rejected_callback() {
+unsafe extern "C" fn rejected_callback() { unsafe {
     G_RET = SyncNbgl::UxSyncRetRejected.into();
     G_ENDED = true;
-}
+}}
 
 pub struct Field<'a> {
     pub name: &'a str,

--- a/ledger_device_sdk/src/nbgl.rs
+++ b/ledger_device_sdk/src/nbgl.rs
@@ -166,57 +166,69 @@ trait SyncNBGL: Sized {
     }
 }
 
-unsafe extern "C" fn choice_callback(confirm: bool) { unsafe {
-    if G_CONFIRM_ASK_WHEN_TRUE || G_CONFIRM_ASK_WHEN_FALSE {
-        let mut idx = 0usize;
-        if G_CONFIRM_ASK_WHEN_TRUE && confirm {
-            idx = G_CONFIRM_SCREEN_WHEN_TRUE_IDX;
-            G_RET = SyncNbgl::UxSyncRetApproved.into();
-        } else if G_CONFIRM_ASK_WHEN_FALSE && !confirm {
-            idx = G_CONFIRM_SCREEN_WHEN_FALSE_IDX;
-            G_RET = SyncNbgl::UxSyncRetRejected.into();
-        }
-        let screen = G_CONFIRM_SCREEN[idx].as_ref().unwrap();
-        nbgl_useCaseConfirm(
-            screen.message.as_ptr() as *const c_char,
-            screen.submessage.as_ptr() as *const c_char,
-            screen.ok_text.as_ptr() as *const c_char,
-            screen.ko_text.as_ptr() as *const c_char,
-            Some(confirm_choice_callback),
-        );
-    } else {
-        G_RET = if confirm {
-            SyncNbgl::UxSyncRetApproved.into()
+unsafe extern "C" fn choice_callback(confirm: bool) {
+    unsafe {
+        if G_CONFIRM_ASK_WHEN_TRUE || G_CONFIRM_ASK_WHEN_FALSE {
+            let mut idx = 0usize;
+            if G_CONFIRM_ASK_WHEN_TRUE && confirm {
+                idx = G_CONFIRM_SCREEN_WHEN_TRUE_IDX;
+                G_RET = SyncNbgl::UxSyncRetApproved.into();
+            } else if G_CONFIRM_ASK_WHEN_FALSE && !confirm {
+                idx = G_CONFIRM_SCREEN_WHEN_FALSE_IDX;
+                G_RET = SyncNbgl::UxSyncRetRejected.into();
+            }
+            let screen = G_CONFIRM_SCREEN[idx].as_ref().unwrap();
+            nbgl_useCaseConfirm(
+                screen.message.as_ptr() as *const c_char,
+                screen.submessage.as_ptr() as *const c_char,
+                screen.ok_text.as_ptr() as *const c_char,
+                screen.ko_text.as_ptr() as *const c_char,
+                Some(confirm_choice_callback),
+            );
         } else {
-            SyncNbgl::UxSyncRetRejected.into()
-        };
+            G_RET = if confirm {
+                SyncNbgl::UxSyncRetApproved.into()
+            } else {
+                SyncNbgl::UxSyncRetRejected.into()
+            };
+            G_ENDED = true;
+        }
+    }
+}
+
+unsafe extern "C" fn confirm_choice_callback() {
+    unsafe {
         G_ENDED = true;
     }
-}}
+}
 
-unsafe extern "C" fn confirm_choice_callback() { unsafe {
-    G_ENDED = true;
-}}
+unsafe extern "C" fn skip_callback() {
+    unsafe {
+        G_RET = SyncNbgl::UxSyncRetSkipped.into();
+        G_ENDED = true;
+    }
+}
 
-unsafe extern "C" fn skip_callback() { unsafe {
-    G_RET = SyncNbgl::UxSyncRetSkipped.into();
-    G_ENDED = true;
-}}
+unsafe extern "C" fn quit_callback() {
+    unsafe {
+        G_RET = SyncNbgl::UxSyncRetQuitted.into();
+        G_ENDED = true;
+    }
+}
 
-unsafe extern "C" fn quit_callback() { unsafe {
-    G_RET = SyncNbgl::UxSyncRetQuitted.into();
-    G_ENDED = true;
-}}
+unsafe extern "C" fn continue_callback() {
+    unsafe {
+        G_RET = SyncNbgl::UxSyncRetContinue.into();
+        G_ENDED = true;
+    }
+}
 
-unsafe extern "C" fn continue_callback() { unsafe {
-    G_RET = SyncNbgl::UxSyncRetContinue.into();
-    G_ENDED = true;
-}}
-
-unsafe extern "C" fn rejected_callback() { unsafe {
-    G_RET = SyncNbgl::UxSyncRetRejected.into();
-    G_ENDED = true;
-}}
+unsafe extern "C" fn rejected_callback() {
+    unsafe {
+        G_RET = SyncNbgl::UxSyncRetRejected.into();
+        G_ENDED = true;
+    }
+}
 
 pub struct Field<'a> {
     pub name: &'a str,

--- a/ledger_device_sdk/src/nbgl/nbgl_generic_review.rs
+++ b/ledger_device_sdk/src/nbgl/nbgl_generic_review.rs
@@ -413,14 +413,16 @@ impl From<&InfosList> for nbgl_contentInfoList_t {
     }
 }
 
-unsafe extern "C" fn action_callback(token: c_int, _index: u8, _page: c_int) { unsafe {
-    if token == FIRST_USER_TOKEN as i32 {
-        G_RET = SyncNbgl::UxSyncRetApproved.into();
-    } else if token == (FIRST_USER_TOKEN + 1) as i32 {
-        G_RET = SyncNbgl::UxSyncRetRejected.into();
+unsafe extern "C" fn action_callback(token: c_int, _index: u8, _page: c_int) {
+    unsafe {
+        if token == FIRST_USER_TOKEN as i32 {
+            G_RET = SyncNbgl::UxSyncRetApproved.into();
+        } else if token == (FIRST_USER_TOKEN + 1) as i32 {
+            G_RET = SyncNbgl::UxSyncRetRejected.into();
+        }
+        G_ENDED = true;
     }
-    G_ENDED = true;
-}}
+}
 
 /// Content element that can be added to an [`NbglGenericReview`] via
 /// [`NbglGenericReview::add_content`].

--- a/ledger_device_sdk/src/nbgl/nbgl_generic_review.rs
+++ b/ledger_device_sdk/src/nbgl/nbgl_generic_review.rs
@@ -413,14 +413,14 @@ impl From<&InfosList> for nbgl_contentInfoList_t {
     }
 }
 
-unsafe extern "C" fn action_callback(token: c_int, _index: u8, _page: c_int) {
+unsafe extern "C" fn action_callback(token: c_int, _index: u8, _page: c_int) { unsafe {
     if token == FIRST_USER_TOKEN as i32 {
         G_RET = SyncNbgl::UxSyncRetApproved.into();
     } else if token == (FIRST_USER_TOKEN + 1) as i32 {
         G_RET = SyncNbgl::UxSyncRetRejected.into();
     }
     G_ENDED = true;
-}
+}}
 
 /// Content element that can be added to an [`NbglGenericReview`] via
 /// [`NbglGenericReview::add_content`].

--- a/ledger_device_sdk/src/nbgl/nbgl_generic_settings.rs
+++ b/ledger_device_sdk/src/nbgl/nbgl_generic_settings.rs
@@ -5,7 +5,7 @@ static mut SWITCH_ARRAY: [nbgl_contentSwitch_t; SETTINGS_SIZE] =
     [unsafe { const_zero!(nbgl_contentSwitch_t) }; SETTINGS_SIZE];
 
 /// Callback triggered by the NBGL API  when a setting switch is toggled.
-unsafe extern "C" fn settings_callback(token: c_int, _index: u8, _page: c_int) {
+unsafe extern "C" fn settings_callback(token: c_int, _index: u8, _page: c_int) { unsafe {
     let idx = token - FIRST_USER_TOKEN as i32;
     if idx < 0 || idx >= SETTINGS_SIZE as i32 {
         panic!("Invalid token.");
@@ -28,7 +28,7 @@ unsafe extern "C" fn settings_callback(token: c_int, _index: u8, _page: c_int) {
         }
         data.update(&switch_values);
     }
-}
+}}
 
 #[derive(Default)]
 struct InfoHolder {

--- a/ledger_device_sdk/src/nbgl/nbgl_generic_settings.rs
+++ b/ledger_device_sdk/src/nbgl/nbgl_generic_settings.rs
@@ -5,30 +5,32 @@ static mut SWITCH_ARRAY: [nbgl_contentSwitch_t; SETTINGS_SIZE] =
     [unsafe { const_zero!(nbgl_contentSwitch_t) }; SETTINGS_SIZE];
 
 /// Callback triggered by the NBGL API  when a setting switch is toggled.
-unsafe extern "C" fn settings_callback(token: c_int, _index: u8, _page: c_int) { unsafe {
-    let idx = token - FIRST_USER_TOKEN as i32;
-    if idx < 0 || idx >= SETTINGS_SIZE as i32 {
-        panic!("Invalid token.");
-    }
-
-    let setting_idx: usize = idx as usize;
-
-    match SWITCH_ARRAY[setting_idx].initState {
-        OFF_STATE => SWITCH_ARRAY[setting_idx].initState = ON_STATE,
-        ON_STATE => SWITCH_ARRAY[setting_idx].initState = OFF_STATE,
-        _ => panic!("Invalid state."),
-    }
-
-    if let Some(data) = (*(&raw mut NVM_REF)).as_mut() {
-        let mut switch_values: [u8; SETTINGS_SIZE] = *data.get_ref();
-        if switch_values[setting_idx] == OFF_STATE {
-            switch_values[setting_idx] = ON_STATE;
-        } else {
-            switch_values[setting_idx] = OFF_STATE;
+unsafe extern "C" fn settings_callback(token: c_int, _index: u8, _page: c_int) {
+    unsafe {
+        let idx = token - FIRST_USER_TOKEN as i32;
+        if idx < 0 || idx >= SETTINGS_SIZE as i32 {
+            panic!("Invalid token.");
         }
-        data.update(&switch_values);
+
+        let setting_idx: usize = idx as usize;
+
+        match SWITCH_ARRAY[setting_idx].initState {
+            OFF_STATE => SWITCH_ARRAY[setting_idx].initState = ON_STATE,
+            ON_STATE => SWITCH_ARRAY[setting_idx].initState = OFF_STATE,
+            _ => panic!("Invalid state."),
+        }
+
+        if let Some(data) = (*(&raw mut NVM_REF)).as_mut() {
+            let mut switch_values: [u8; SETTINGS_SIZE] = *data.get_ref();
+            if switch_values[setting_idx] == OFF_STATE {
+                switch_values[setting_idx] = ON_STATE;
+            } else {
+                switch_values[setting_idx] = OFF_STATE;
+            }
+            data.update(&switch_values);
+        }
     }
-}}
+}
 
 #[derive(Default)]
 struct InfoHolder {

--- a/ledger_device_sdk/src/nbgl/nbgl_home_and_settings.rs
+++ b/ledger_device_sdk/src/nbgl/nbgl_home_and_settings.rs
@@ -13,7 +13,7 @@ static mut SWITCH_ARRAY: [nbgl_contentSwitch_t; SETTINGS_SIZE] =
     [unsafe { const_zero!(nbgl_contentSwitch_t) }; SETTINGS_SIZE];
 
 /// Callback triggered by the NBGL API when a setting switch is toggled.
-unsafe extern "C" fn settings_callback(token: c_int, _index: u8, _page: c_int) {
+unsafe extern "C" fn settings_callback(token: c_int, _index: u8, _page: c_int) { unsafe {
     let idx = token - FIRST_USER_TOKEN as i32;
     if idx < 0 || idx >= SETTINGS_SIZE as i32 {
         panic!("Invalid token.");
@@ -36,7 +36,7 @@ unsafe extern "C" fn settings_callback(token: c_int, _index: u8, _page: c_int) {
         }
         data.update(&switch_values);
     }
-}
+}}
 
 /// Informations fields name to display in the dedicated
 /// page of the home screen.
@@ -270,12 +270,12 @@ impl<'a> NbglHomeAndSettings {
                         if let Some(hdr) = nbgl_fetch_apdu_header() {
                             // Reconstruct minimal Event::Command using APDU header only.
                             // The generic parameter T: TryFrom<ApduHeader> will parse header.
-                            if let Ok(ins) = T::try_from(hdr) {
+                            match T::try_from(hdr) { Ok(ins) => {
                                 return Event::Command(ins);
-                            } else {
+                            } _ => {
                                 // In case of parse error we emulate a BadIns reply.
                                 nbgl_reply_status(Reply(StatusWords::BadIns as u16));
-                            }
+                            }}
                         }
                     }
                     SyncNbgl::UxSyncRetQuitted => {

--- a/ledger_device_sdk/src/nbgl/nbgl_home_and_settings.rs
+++ b/ledger_device_sdk/src/nbgl/nbgl_home_and_settings.rs
@@ -13,30 +13,32 @@ static mut SWITCH_ARRAY: [nbgl_contentSwitch_t; SETTINGS_SIZE] =
     [unsafe { const_zero!(nbgl_contentSwitch_t) }; SETTINGS_SIZE];
 
 /// Callback triggered by the NBGL API when a setting switch is toggled.
-unsafe extern "C" fn settings_callback(token: c_int, _index: u8, _page: c_int) { unsafe {
-    let idx = token - FIRST_USER_TOKEN as i32;
-    if idx < 0 || idx >= SETTINGS_SIZE as i32 {
-        panic!("Invalid token.");
-    }
-
-    let setting_idx: usize = idx as usize;
-
-    match SWITCH_ARRAY[setting_idx].initState {
-        OFF_STATE => SWITCH_ARRAY[setting_idx].initState = ON_STATE,
-        ON_STATE => SWITCH_ARRAY[setting_idx].initState = OFF_STATE,
-        _ => panic!("Invalid state."),
-    }
-
-    if let Some(data) = (*(&raw mut NVM_REF)).as_mut() {
-        let mut switch_values: [u8; SETTINGS_SIZE] = *data.get_ref();
-        if switch_values[setting_idx] == OFF_STATE {
-            switch_values[setting_idx] = ON_STATE;
-        } else {
-            switch_values[setting_idx] = OFF_STATE;
+unsafe extern "C" fn settings_callback(token: c_int, _index: u8, _page: c_int) {
+    unsafe {
+        let idx = token - FIRST_USER_TOKEN as i32;
+        if idx < 0 || idx >= SETTINGS_SIZE as i32 {
+            panic!("Invalid token.");
         }
-        data.update(&switch_values);
+
+        let setting_idx: usize = idx as usize;
+
+        match SWITCH_ARRAY[setting_idx].initState {
+            OFF_STATE => SWITCH_ARRAY[setting_idx].initState = ON_STATE,
+            ON_STATE => SWITCH_ARRAY[setting_idx].initState = OFF_STATE,
+            _ => panic!("Invalid state."),
+        }
+
+        if let Some(data) = (*(&raw mut NVM_REF)).as_mut() {
+            let mut switch_values: [u8; SETTINGS_SIZE] = *data.get_ref();
+            if switch_values[setting_idx] == OFF_STATE {
+                switch_values[setting_idx] = ON_STATE;
+            } else {
+                switch_values[setting_idx] = OFF_STATE;
+            }
+            data.update(&switch_values);
+        }
     }
-}}
+}
 
 /// Informations fields name to display in the dedicated
 /// page of the home screen.
@@ -270,12 +272,15 @@ impl<'a> NbglHomeAndSettings {
                         if let Some(hdr) = nbgl_fetch_apdu_header() {
                             // Reconstruct minimal Event::Command using APDU header only.
                             // The generic parameter T: TryFrom<ApduHeader> will parse header.
-                            match T::try_from(hdr) { Ok(ins) => {
-                                return Event::Command(ins);
-                            } _ => {
-                                // In case of parse error we emulate a BadIns reply.
-                                nbgl_reply_status(Reply(StatusWords::BadIns as u16));
-                            }}
+                            match T::try_from(hdr) {
+                                Ok(ins) => {
+                                    return Event::Command(ins);
+                                }
+                                _ => {
+                                    // In case of parse error we emulate a BadIns reply.
+                                    nbgl_reply_status(Reply(StatusWords::BadIns as u16));
+                                }
+                            }
                         }
                     }
                     SyncNbgl::UxSyncRetQuitted => {

--- a/ledger_device_sdk/src/nbgl/nbgl_keypad.rs
+++ b/ledger_device_sdk/src/nbgl/nbgl_keypad.rs
@@ -18,8 +18,9 @@ static mut PIN_BUFFER: [u8; 16] = [0x00; 16];
 
 unsafe extern "C" fn pin_callback(pin: *const u8, pin_len: u8) {
     unsafe {
-        for i in 0..pin_len {
-            PIN_BUFFER[i as usize] = *pin.add(i.into());
+        let len = (pin_len as usize).min(PIN_BUFFER.len());
+        for i in 0..len {
+            PIN_BUFFER[i] = *pin.add(i);
         }
         G_ENDED = true;
     }
@@ -77,9 +78,11 @@ impl NbglKeypad {
     /// # Returns
     /// Returns the builder itself to allow method chaining.
     pub fn max_digits(self, max: u8) -> NbglKeypad {
-        NbglKeypad {
-            max_digits: max,
-            ..self
+        unsafe {
+            NbglKeypad {
+                max_digits: max.min(PIN_BUFFER.len() as u8),
+                ..self
+            }
         }
     }
 

--- a/ledger_device_sdk/src/nbgl/nbgl_keypad.rs
+++ b/ledger_device_sdk/src/nbgl/nbgl_keypad.rs
@@ -16,17 +16,17 @@ impl SyncNBGL for NbglKeypad {}
 
 static mut PIN_BUFFER: [u8; 16] = [0x00; 16];
 
-unsafe extern "C" fn pin_callback(pin: *const u8, pin_len: u8) {
+unsafe extern "C" fn pin_callback(pin: *const u8, pin_len: u8) { unsafe {
     for i in 0..pin_len {
         PIN_BUFFER[i as usize] = *pin.add(i.into());
     }
     G_ENDED = true;
-}
+}}
 
-unsafe extern "C" fn action_callback() {
+unsafe extern "C" fn action_callback() { unsafe {
     G_RET = SyncNbgl::UxSyncRetPinRejected.into();
     G_ENDED = true;
-}
+}}
 
 impl NbglKeypad {
     /// Creates a new keypad builder with default settings.

--- a/ledger_device_sdk/src/nbgl/nbgl_keypad.rs
+++ b/ledger_device_sdk/src/nbgl/nbgl_keypad.rs
@@ -16,17 +16,21 @@ impl SyncNBGL for NbglKeypad {}
 
 static mut PIN_BUFFER: [u8; 16] = [0x00; 16];
 
-unsafe extern "C" fn pin_callback(pin: *const u8, pin_len: u8) { unsafe {
-    for i in 0..pin_len {
-        PIN_BUFFER[i as usize] = *pin.add(i.into());
+unsafe extern "C" fn pin_callback(pin: *const u8, pin_len: u8) {
+    unsafe {
+        for i in 0..pin_len {
+            PIN_BUFFER[i as usize] = *pin.add(i.into());
+        }
+        G_ENDED = true;
     }
-    G_ENDED = true;
-}}
+}
 
-unsafe extern "C" fn action_callback() { unsafe {
-    G_RET = SyncNbgl::UxSyncRetPinRejected.into();
-    G_ENDED = true;
-}}
+unsafe extern "C" fn action_callback() {
+    unsafe {
+        G_RET = SyncNbgl::UxSyncRetPinRejected.into();
+        G_ENDED = true;
+    }
+}
 
 impl NbglKeypad {
     /// Creates a new keypad builder with default settings.

--- a/ledger_device_sdk/src/nbgl/nbgl_keypad.rs
+++ b/ledger_device_sdk/src/nbgl/nbgl_keypad.rs
@@ -14,11 +14,12 @@ pub struct NbglKeypad {
 
 impl SyncNBGL for NbglKeypad {}
 
-static mut PIN_BUFFER: [u8; 16] = [0x00; 16];
+const PIN_BUFFER_SIZE: usize = 16;
+static mut PIN_BUFFER: [u8; PIN_BUFFER_SIZE] = [0x00; PIN_BUFFER_SIZE];
 
 unsafe extern "C" fn pin_callback(pin: *const u8, pin_len: u8) {
     unsafe {
-        let len = (pin_len as usize).min(PIN_BUFFER.len());
+        let len = (pin_len as usize).min(PIN_BUFFER_SIZE);
         for i in 0..len {
             PIN_BUFFER[i] = *pin.add(i);
         }
@@ -78,11 +79,9 @@ impl NbglKeypad {
     /// # Returns
     /// Returns the builder itself to allow method chaining.
     pub fn max_digits(self, max: u8) -> NbglKeypad {
-        unsafe {
-            NbglKeypad {
-                max_digits: max.min(PIN_BUFFER.len() as u8),
-                ..self
-            }
+        NbglKeypad {
+            max_digits: max.min(PIN_BUFFER_SIZE as u8),
+            ..self
         }
     }
 

--- a/ledger_device_sdk/src/nvm.rs
+++ b/ledger_device_sdk/src/nvm.rs
@@ -170,7 +170,7 @@ impl<T> SingleStorage<T> for SafeStorage<T> {
 /// Aligning to the required page size is done through a macro
 /// as `#[repr(align(N))]` does not accept variable 'N'
 macro_rules! atomic_storage {
-    ($n:expr) => {
+    ($n:expr_2021) => {
         #[repr(align($n))]
         pub struct AtomicStorage<T> {
             // We must keep the storage B in another page, so when we update the

--- a/ledger_device_sdk/src/nvm.rs
+++ b/ledger_device_sdk/src/nvm.rs
@@ -40,8 +40,8 @@
 //! println!("counter value is {}", *counter.get_ref());
 //! ```
 
-use ledger_secure_sdk_sys::nvm_write;
 use AtomicStorageElem::{StorageA, StorageB};
+use ledger_secure_sdk_sys::nvm_write;
 
 // Warning: currently alignment is fixed by magic values everywhere, since
 // rust does not allow using a constant in repr(align(...))

--- a/ledger_device_sdk/src/nvm.rs
+++ b/ledger_device_sdk/src/nvm.rs
@@ -170,7 +170,7 @@ impl<T> SingleStorage<T> for SafeStorage<T> {
 /// Aligning to the required page size is done through a macro
 /// as `#[repr(align(N))]` does not accept variable 'N'
 macro_rules! atomic_storage {
-    ($n:expr_2021) => {
+    ($n:expr) => {
         #[repr(align($n))]
         pub struct AtomicStorage<T> {
             // We must keep the storage B in another page, so when we update the

--- a/ledger_device_sdk/src/pki.rs
+++ b/ledger_device_sdk/src/pki.rs
@@ -5,7 +5,7 @@
 use crate::ecc::CurvesId;
 use crate::io::Reply;
 use ledger_secure_sdk_sys::{
-    cx_ecfp_384_public_key_t, os_pki_get_info, os_pki_verify, CERTIFICATE_TRUSTED_NAME_MAXLEN,
+    CERTIFICATE_TRUSTED_NAME_MAXLEN, cx_ecfp_384_public_key_t, os_pki_get_info, os_pki_verify,
 };
 
 /// PKI verification errors

--- a/ledger_device_sdk/src/screen.rs
+++ b/ledger_device_sdk/src/screen.rs
@@ -1,4 +1,4 @@
-extern "C" {
+unsafe extern "C" {
     fn screen_clear();
     fn screen_update();
     fn screen_set_keepout(x: u32, y: u32, width: u32, height: u32);

--- a/ledger_device_sdk/src/testing.rs
+++ b/ledger_device_sdk/src/testing.rs
@@ -125,7 +125,7 @@ pub fn sdk_test_runner(tests: &[&TestType]) {
 #[cfg(feature = "unit_test")]
 #[macro_export]
 macro_rules! assert_eq_err {
-    ($left:expr, $right:expr) => {{
+    ($left:expr_2021, $right:expr_2021) => {{
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {

--- a/ledger_device_sdk/src/testing.rs
+++ b/ledger_device_sdk/src/testing.rs
@@ -125,7 +125,7 @@ pub fn sdk_test_runner(tests: &[&TestType]) {
 #[cfg(feature = "unit_test")]
 #[macro_export]
 macro_rules! assert_eq_err {
-    ($left:expr_2021, $right:expr_2021) => {{
+    ($left:expr, $right:expr) => {{
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {

--- a/ledger_device_sdk/src/tlv/tlv_dynamic_token.rs
+++ b/ledger_device_sdk/src/tlv/tlv_dynamic_token.rs
@@ -19,8 +19,8 @@
 
 use super::tlv_generic::*;
 use crate::ecc::CurvesId;
-use crate::hash::sha2::Sha2_256;
 use crate::hash::HashInit;
+use crate::hash::sha2::Sha2_256;
 use crate::pki::pki_check_signature;
 use crate::tag_to_flag_u64;
 use ledger_secure_sdk_sys::CERTIFICATE_PUBLIC_KEY_USAGE_COIN_META;
@@ -232,7 +232,7 @@ pub fn parse_dynamic_token_tlv(payload: &[u8], out: &mut DynamicTokenOut) -> Res
 mod tests {
     use crate::assert_eq_err as assert_eq;
     use crate::testing::TestType;
-    use crate::tlv::{parse_dynamic_token_tlv, DynamicTokenOut};
+    use crate::tlv::{DynamicTokenOut, parse_dynamic_token_tlv};
     use testmacro::test_item as test;
 
     const TLV_PAYLOAD: &[u8] = &[

--- a/ledger_device_sdk/src/tlv/tlv_trusted_name.rs
+++ b/ledger_device_sdk/src/tlv/tlv_trusted_name.rs
@@ -375,7 +375,7 @@ pub fn parse_trusted_name_tlv(payload: &[u8], out: &mut TrustedNameOut) -> Resul
 
 // Helper macro to reduce boilerplate for hash finalization
 macro_rules! finalize_hash {
-    ($hash_ctx:expr_2021, $curve_id:expr_2021, $hash:expr_2021, $hash_size:expr_2021, $curve:expr_2021) => {{
+    ($hash_ctx:expr, $curve_id:expr, $hash:expr, $hash_size:expr, $curve:expr) => {{
         *$hash_size = $hash_ctx.get_size();
         *$curve = $curve_id;
         $hash_ctx

--- a/ledger_device_sdk/src/tlv/tlv_trusted_name.rs
+++ b/ledger_device_sdk/src/tlv/tlv_trusted_name.rs
@@ -18,10 +18,10 @@
 
 use super::tlv_generic::*;
 use crate::ecc::CurvesId;
+use crate::hash::HashInit;
 use crate::hash::ripemd::Ripemd160;
 use crate::hash::sha2::{Sha2_256, Sha2_512};
 use crate::hash::sha3::{Keccak256, Sha3_256};
-use crate::hash::HashInit;
 use crate::pki::pki_check_signature;
 use crate::tag_to_flag_u64;
 use ledger_secure_sdk_sys::CERTIFICATE_PUBLIC_KEY_USAGE_TRUSTED_NAME;
@@ -474,7 +474,7 @@ fn finalize_hashes(
 mod tests {
     use crate::assert_eq_err as assert_eq;
     use crate::testing::TestType;
-    use crate::tlv::{parse_trusted_name_tlv, TrustedNameOut};
+    use crate::tlv::{TrustedNameOut, parse_trusted_name_tlv};
     use testmacro::test_item as test;
 
     const TLV_PAYLOAD: &[u8] = &[

--- a/ledger_device_sdk/src/tlv/tlv_trusted_name.rs
+++ b/ledger_device_sdk/src/tlv/tlv_trusted_name.rs
@@ -375,7 +375,7 @@ pub fn parse_trusted_name_tlv(payload: &[u8], out: &mut TrustedNameOut) -> Resul
 
 // Helper macro to reduce boilerplate for hash finalization
 macro_rules! finalize_hash {
-    ($hash_ctx:expr, $curve_id:expr, $hash:expr, $hash_size:expr, $curve:expr) => {{
+    ($hash_ctx:expr_2021, $curve_id:expr_2021, $hash:expr_2021, $hash_size:expr_2021, $curve:expr_2021) => {{
         *$hash_size = $hash_ctx.get_size();
         *$curve = $curve_id;
         $hash_ctx

--- a/ledger_device_sdk/src/ui/bitmaps.rs
+++ b/ledger_device_sdk/src/ui/bitmaps.rs
@@ -58,7 +58,7 @@ use include_gif::include_gif;
 
 pub const BLANK: [u8; 1024] = [0u8; 1024];
 
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the back icon.
     pub static C_icon_back_bitmap: [u8; 25];
 }
@@ -68,7 +68,7 @@ pub static BACK: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_back_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the back_x icon.
     pub static C_icon_back_x_bitmap: [u8; 25];
 }
@@ -78,7 +78,7 @@ pub static BACK_X: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_back_x_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the coggle icon.
     pub static C_icon_coggle_bitmap: [u8; 25];
 }
@@ -88,7 +88,7 @@ pub static COGGLE: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_coggle_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the processing icon.
     pub static C_icon_down_bitmap: [u8; 4];
 }
@@ -98,7 +98,7 @@ pub static DOWN_ARROW: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_down_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the left arrow icon.
     pub static C_icon_left_bitmap: [u8; 4];
 }
@@ -108,7 +108,7 @@ pub static LEFT_ARROW: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_left_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the right arrow icon.
     pub static C_icon_right_bitmap: [u8; 4];
 }
@@ -118,7 +118,7 @@ pub static RIGHT_ARROW: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_right_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the up arrow icon.
     pub static C_icon_up_bitmap: [u8; 4];
 }
@@ -128,7 +128,7 @@ pub static UP_ARROW: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_up_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the certificate icon.
     pub static C_icon_certificate_bitmap: [u8; 25];
 }
@@ -138,7 +138,7 @@ pub static CERTIFICATE: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_certificate_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the crossmark icon.
     pub static C_icon_crossmark_bitmap: [u8; 25];
 }
@@ -150,7 +150,7 @@ pub static CROSSMARK: Glyph = Glyph {
 };
 // This is a special case for the cross icon, which is a GIF (used by client apps)
 pub const CROSS: Glyph = Glyph::from_include(include_gif!("icons/icon_cross_badge.gif"));
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the dashboard icon.
     pub static C_icon_dashboard_bitmap: [u8; 25];
 }
@@ -160,7 +160,7 @@ pub static DASHBOARD: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_dashboard_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the dashboard x icon.
     pub static C_icon_dashboard_x_bitmap: [u8; 25];
 }
@@ -170,7 +170,7 @@ pub static DASHBOARD_X: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_dashboard_x_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the eye icon.
     pub static C_icon_eye_bitmap: [u8; 25];
 }
@@ -180,7 +180,7 @@ pub static EYE: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_eye_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the processing icon.
     pub static C_icon_processing_bitmap: [u8; 25];
 }
@@ -190,7 +190,7 @@ pub static PROCESSING: Glyph = Glyph {
     height: ledger_secure_sdk_sys::GLYPH_icon_processing_HEIGHT,
     inverted: false,
 };
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the validate icon.
     pub static C_icon_validate_14_bitmap: [u8; 25];
 }
@@ -202,7 +202,7 @@ pub static VALIDATE_14: Glyph = Glyph {
 };
 // This is a special case for the checkmark icon, which is a GIF (used by client apps)
 pub const CHECKMARK: Glyph = Glyph::from_include(include_gif!("icons/badge_check.gif"));
-extern "C" {
+unsafe extern "C" {
     /// The bitmap for the warning icon.
     pub static C_icon_warning_bitmap: [u8; 25];
 }

--- a/ledger_device_sdk/src/ui/gadgets.rs
+++ b/ledger_device_sdk/src/ui/gadgets.rs
@@ -1,10 +1,10 @@
 use crate::{
     buttons::ButtonEvent::*,
     io::{self, ApduHeader, Comm, Event, Reply},
-    uxapp::{UxEvent, BOLOS_UX_OK},
+    uxapp::{BOLOS_UX_OK, UxEvent},
 };
 use ledger_secure_sdk_sys::{
-    buttons::{get_button_event, ButtonEvent, ButtonsState},
+    buttons::{ButtonEvent, ButtonsState, get_button_event},
     seph,
 };
 

--- a/ledger_device_sdk/src/ui/string_se.rs
+++ b/ledger_device_sdk/src/ui/string_se.rs
@@ -4,7 +4,7 @@ use crate::ui::screen_util::{draw, screen_update};
 use core::ffi::c_void;
 use ledger_secure_sdk_sys;
 
-extern "C" {
+unsafe extern "C" {
     fn pic(link_address: *mut c_void) -> *mut c_void;
 }
 

--- a/ledger_secure_sdk_sys/Cargo.toml
+++ b/ledger_secure_sdk_sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ledger_secure_sdk_sys"
 version = "1.15.0"
 authors = ["Ledger"]
-edition = "2021"
+edition = "2024"
 license.workspace = true
 repository.workspace = true
 description = "Bindings to Ledger C SDK"

--- a/ledger_secure_sdk_sys/build.rs
+++ b/ledger_secure_sdk_sys/build.rs
@@ -715,7 +715,9 @@ impl SDKBuilder<'_> {
 
         assert!(
             (2048..=max_heap_size).contains(&heap_size_value),
-            "Invalid heap size specification '{raw}'; resolved value {heap_size_value} must be in [2048, {}] for target {}", max_heap_size, target_os
+            "Invalid heap size specification '{raw}'; resolved value {heap_size_value} must be in [2048, {}] for target {}",
+            max_heap_size,
+            target_os
         );
 
         let out_dir = env::var("OUT_DIR").unwrap();

--- a/ledger_secure_sdk_sys/src/infos.rs
+++ b/ledger_secure_sdk_sys/src/infos.rs
@@ -13,9 +13,9 @@ pub const fn str_to_bytes<const N: usize>(s: &str) -> [u8; N] {
 
 #[macro_export]
 macro_rules! const_cstr {
-    ($name: ident, $section: literal, $in_str: expr) => {
+    ($name: ident, $section: literal, $in_str: expr_2021) => {
         #[used]
-        #[link_section = $section]
+        #[unsafe(link_section = $section)]
         static $name: [u8; $in_str.len() + 1] = str_to_bytes($in_str);
     };
 }

--- a/ledger_secure_sdk_sys/src/infos.rs
+++ b/ledger_secure_sdk_sys/src/infos.rs
@@ -13,7 +13,7 @@ pub const fn str_to_bytes<const N: usize>(s: &str) -> [u8; N] {
 
 #[macro_export]
 macro_rules! const_cstr {
-    ($name: ident, $section: literal, $in_str: expr_2021) => {
+    ($name: ident, $section: literal, $in_str: expr) => {
         #[used]
         #[unsafe(link_section = $section)]
         static $name: [u8; $in_str.len() + 1] = str_to_bytes($in_str);

--- a/ledger_secure_sdk_sys/src/lib.rs
+++ b/ledger_secure_sdk_sys/src/lib.rs
@@ -69,7 +69,7 @@ extern "C" fn heap_init() {
     unsafe { HEAP.init(&raw mut HEAP_MEM as usize, HEAP_SIZE) }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[cfg(any(not(feature = "heap")))]
 extern "C" fn heap_init() {}
 

--- a/ledger_secure_sdk_sys/src/lib.rs
+++ b/ledger_secure_sdk_sys/src/lib.rs
@@ -50,10 +50,12 @@ struct CriticalSection;
 #[cfg(feature = "heap")]
 critical_section::set_impl!(CriticalSection);
 
-/// Default empty implementation as we don't have concurrency.
+/// Default no-op implementation as we don't have concurrency.
 #[cfg(feature = "heap")]
 unsafe impl critical_section::Impl for CriticalSection {
-    unsafe fn acquire() -> RawRestoreState {}
+    unsafe fn acquire() -> RawRestoreState {
+        ()
+    }
     unsafe fn release(_restore_state: RawRestoreState) {}
 }
 

--- a/ledger_secure_sdk_sys/src/lib.rs
+++ b/ledger_secure_sdk_sys/src/lib.rs
@@ -36,22 +36,22 @@ pub fn pic_rs_mut<T>(x: &mut T) -> &mut T {
     unsafe { &mut *ptr }
 }
 
-#[cfg(all(feature = "heap"))]
+#[cfg(feature = "heap")]
 use critical_section::RawRestoreState;
-#[cfg(all(feature = "heap"))]
+#[cfg(feature = "heap")]
 use embedded_alloc::Heap;
 
-#[cfg(all(feature = "heap"))]
+#[cfg(feature = "heap")]
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 
-#[cfg(all(feature = "heap"))]
+#[cfg(feature = "heap")]
 struct CriticalSection;
-#[cfg(all(feature = "heap"))]
+#[cfg(feature = "heap")]
 critical_section::set_impl!(CriticalSection);
 
 /// Default empty implementation as we don't have concurrency.
-#[cfg(all(feature = "heap"))]
+#[cfg(feature = "heap")]
 unsafe impl critical_section::Impl for CriticalSection {
     unsafe fn acquire() -> RawRestoreState {}
     unsafe fn release(_restore_state: RawRestoreState) {}
@@ -61,8 +61,8 @@ unsafe impl critical_section::Impl for CriticalSection {
 ///
 /// The heap is stored in the stack, and has a fixed size.
 /// This method is called just before [sample_main].
-#[no_mangle]
-#[cfg(all(feature = "heap"))]
+#[unsafe(no_mangle)]
+#[cfg(feature = "heap")]
 extern "C" fn heap_init() {
     // HEAP_SIZE comes from heap_size.rs, which is defined via env var and build.rs
     static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
@@ -70,7 +70,7 @@ extern "C" fn heap_init() {
 }
 
 #[unsafe(no_mangle)]
-#[cfg(any(not(feature = "heap")))]
+#[cfg(not(feature = "heap"))]
 extern "C" fn heap_init() {}
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/ledger_secure_sdk_sys/src/seph.rs
+++ b/ledger_secure_sdk_sys/src/seph.rs
@@ -7,7 +7,7 @@ mod canary {
     // will panic if corruption is detected.
     // This might later be removed if such protection is provided in the C SDK.
 
-    extern "C" {
+    unsafe extern "C" {
         /// Stack canary symbol provided by the linker script
         static mut app_stack_canary: u32;
     }

--- a/testmacro/Cargo.toml
+++ b/testmacro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "testmacro"
 version = "0.1.0"
 authors = ["yhql <yhql@users.noreply.github.com>"]
-edition = "2018"
+edition = "2024"
 license.workspace = true
 repository.workspace = true
 description = "procedural macro used to run unit and integration tests"


### PR DESCRIPTION
This PR migrates all crates of Rust SDK from edition 2021 to edition 2024.
See https://doc.rust-lang.org/edition-guide/rust-2024/index.html for more information